### PR TITLE
test: improve gopool benchmark

### DIFF
--- a/util/gopool/pool_test.go
+++ b/util/gopool/pool_test.go
@@ -15,20 +15,25 @@
 package gopool
 
 import (
-	"fmt"
-	"math/rand"
 	"runtime"
 	"sync"
 	"sync/atomic"
 	"testing"
+
+	"github.com/bytedance/gopkg/lang/fastrand"
 )
 
 const benchmarkTimes = 10000
 
-func testFunc() {
-	for i := 0; i < benchmarkTimes; i++ {
-		rand.Intn(benchmarkTimes)
+func DoCopyStack(a, b int) int {
+	if fastrand.Uint32n(100) == 0 {
+		return 0
 	}
+	return DoCopyStack(1, 2)
+}
+
+func testFunc() {
+	DoCopyStack(1, 2)
 }
 
 func testPanicFunc() {
@@ -58,7 +63,6 @@ func TestPoolPanic(t *testing.T) {
 }
 
 func BenchmarkPool(b *testing.B) {
-	fmt.Println(runtime.GOMAXPROCS(0))
 	config := NewConfig()
 	config.ScaleThreshold = 1
 	p := NewPool("benchmark", int32(runtime.GOMAXPROCS(0)), config)

--- a/util/gopool/pool_test.go
+++ b/util/gopool/pool_test.go
@@ -19,21 +19,19 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
-
-	"github.com/bytedance/gopkg/lang/fastrand"
 )
 
 const benchmarkTimes = 10000
 
 func DoCopyStack(a, b int) int {
-	if fastrand.Uint32n(100) == 0 {
-		return 0
+	if b < 100 {
+		return DoCopyStack(0, b+1)
 	}
-	return DoCopyStack(1, 2)
+	return 0
 }
 
 func testFunc() {
-	DoCopyStack(1, 2)
+	DoCopyStack(0, 0)
 }
 
 func testPanicFunc() {


### PR DESCRIPTION
This PR improve two points:

- Makes the benchmark scalable. The previous benchmark use `math/rand`, it is wrapped by a `sync.Mutex`, so only one CPU can be used in the test function.
- Benchmark gopool in `copystack` situation. After makes the benchmark scalable, the gopool's speed almost equal to the std `go`, but consumes 10x memory.

(testFunc trigger copystack)
name     time/op
Pool-12  4.03ms ± 3%
Go-12    9.33ms ± 0%