### PR TITLE
feat(metainfo): improve performance and reduce memory allocation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@
 # IDE or Editor's config
 .idea/
 
+testdata

--- a/cloud/metainfo/info_test.go
+++ b/cloud/metainfo/info_test.go
@@ -332,6 +332,12 @@ func benchmark(b *testing.B, api string, count int) {
 		for i := 0; i < b.N; i++ {
 			_ = metainfo.WithValue(ctx, "key", "val")
 		}
+	case "WithValueAcc":
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			ctx = metainfo.WithValue(ctx, "key", "val")
+		}
 	case "DelValue":
 		b.ReportAllocs()
 		b.ResetTimer()
@@ -356,11 +362,34 @@ func benchmark(b *testing.B, api string, count int) {
 		for i := 0; i < b.N; i++ {
 			_ = metainfo.WithPersistentValue(ctx, "key", "val")
 		}
+	case "WithPersistentValueAcc":
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			ctx = metainfo.WithPersistentValue(ctx, "key", "val")
+		}
+		_ = ctx
 	case "DelPersistentValue":
 		b.ReportAllocs()
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			_ = metainfo.DelPersistentValue(ctx, "key")
+		}
+	case "SaveMetaInfoToMap":
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			m := make(map[string]string)
+			metainfo.SaveMetaInfoToMap(ctx, m)
+		}
+	case "SetMetaInfoFromMap":
+		m := make(map[string]string)
+		c := context.Background()
+		metainfo.SaveMetaInfoToMap(ctx, m)
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			_ = metainfo.SetMetaInfoFromMap(c, m)
 		}
 	}
 }
@@ -400,6 +429,15 @@ func benchmarkParallel(b *testing.B, api string, count int) {
 				_ = metainfo.WithValue(ctx, "key", "val")
 			}
 		})
+	case "WithValueAcc":
+		b.ReportAllocs()
+		b.ResetTimer()
+		b.RunParallel(func(pb *testing.PB) {
+			tmp := ctx
+			for pb.Next() {
+				tmp = metainfo.WithValue(tmp, "key", "val")
+			}
+		})
 	case "DelValue":
 		b.ReportAllocs()
 		b.ResetTimer()
@@ -432,12 +470,41 @@ func benchmarkParallel(b *testing.B, api string, count int) {
 				_ = metainfo.WithPersistentValue(ctx, "key", "val")
 			}
 		})
+	case "WithPersistentValueAcc":
+		b.ReportAllocs()
+		b.ResetTimer()
+		b.RunParallel(func(pb *testing.PB) {
+			tmp := ctx
+			for pb.Next() {
+				tmp = metainfo.WithPersistentValue(tmp, "key", "val")
+			}
+		})
 	case "DelPersistentValue":
 		b.ReportAllocs()
 		b.ResetTimer()
 		b.RunParallel(func(pb *testing.PB) {
 			for pb.Next() {
 				_ = metainfo.DelPersistentValue(ctx, "key")
+			}
+		})
+	case "SaveMetaInfoToMap":
+		b.ReportAllocs()
+		b.ResetTimer()
+		b.RunParallel(func(pb *testing.PB) {
+			for pb.Next() {
+				m := make(map[string]string)
+				metainfo.SaveMetaInfoToMap(ctx, m)
+			}
+		})
+	case "SetMetaInfoFromMap":
+		m := make(map[string]string)
+		c := context.Background()
+		metainfo.SaveMetaInfoToMap(ctx, m)
+		b.ReportAllocs()
+		b.ResetTimer()
+		b.RunParallel(func(pb *testing.PB) {
+			for pb.Next() {
+				_ = metainfo.SetMetaInfoFromMap(c, m)
 			}
 		})
 	}
@@ -449,11 +516,15 @@ func BenchmarkAll(b *testing.B) {
 		"GetValue",
 		"GetAllValues",
 		"WithValue",
+		"WithValueAcc",
 		"DelValue",
 		"GetPersistentValue",
 		"GetAllPersistentValues",
 		"WithPersistentValue",
+		"WithPersistentValueAcc",
 		"DelPersistentValue",
+		"SaveMetaInfoToMap",
+		"SetMetaInfoFromMap",
 	}
 	for _, api := range APIs {
 		api := api
@@ -467,11 +538,15 @@ func BenchmarkAllParallel(b *testing.B) {
 		"GetValue",
 		"GetAllValues",
 		"WithValue",
+		"WithValueAcc",
 		"DelValue",
 		"GetPersistentValue",
 		"GetAllPersistentValues",
 		"WithPersistentValue",
+		"WithPersistentValueAcc",
 		"DelPersistentValue",
+		"SaveMetaInfoToMap",
+		"SetMetaInfoFromMap",
 	}
 	for _, api := range APIs {
 		api := api

--- a/cloud/metainfo/utils.go
+++ b/cloud/metainfo/utils.go
@@ -21,7 +21,7 @@ import (
 
 // HasMetaInfo detects whether the given context contains metainfo.
 func HasMetaInfo(ctx context.Context) bool {
-	return getKV(ctx) != nil
+	return getNode(ctx) != nil
 }
 
 // SetMetaInfoFromMap retrieves metainfo key-value pairs from the given map and sets then into the context.
@@ -30,12 +30,34 @@ func SetMetaInfoFromMap(ctx context.Context, m map[string]string) context.Contex
 	if ctx == nil {
 		return nil
 	}
+
+	var n node
 	for k, v := range m {
-		if t, nk := determineKeyType(k, v); t != invalidType {
-			ctx = addKV(ctx, t, nk, v)
+		if len(k) == 0 || len(v) == 0 {
+			continue
+		}
+
+		switch {
+		case strings.HasPrefix(k, PrefixTransientUpstream):
+			if len(k) > lenPTU { // do not move this condition to the case statement to prevent a PTU matches PT
+				n.stale = append(n.stale, kv{key: k[lenPTU:], val: v})
+			}
+		case strings.HasPrefix(k, PrefixTransient):
+			if len(k) > lenPT {
+				n.transient = append(n.transient, kv{key: k[lenPT:], val: v})
+			}
+		case strings.HasPrefix(k, PrefixPersistent):
+			if len(k) > lenPP {
+				n.persistent = append(n.persistent, kv{key: k[lenPP:], val: v})
+			}
 		}
 	}
-	return ctx
+
+	if n.size() == 0 {
+		// TODO: remove this?
+		return ctx
+	}
+	return withNode(ctx, &n)
 }
 
 // SaveMetaInfoToMap set key-value pairs from ctx to m while filtering out transient-upstream data.
@@ -50,33 +72,4 @@ func SaveMetaInfoToMap(ctx context.Context, m map[string]string) {
 	for k, v := range GetAllPersistentValues(ctx) {
 		m[PrefixPersistent+k] = v
 	}
-}
-
-const (
-	lenPTU = len(PrefixTransientUpstream)
-	lenPT  = len(PrefixTransient)
-	lenPP  = len(PrefixPersistent)
-)
-
-// determineKeyType tests whether the given key-value pair is a valid metainfo and returns its info type with a new appropriate key.
-func determineKeyType(k, v string) (infoType infoType, newKey string) {
-	if len(k) == 0 || len(v) == 0 {
-		return invalidType, k
-	}
-
-	switch {
-	case strings.HasPrefix(k, PrefixTransientUpstream):
-		if len(k) > lenPTU {
-			return transientUpstreamType, k[lenPTU:]
-		}
-	case strings.HasPrefix(k, PrefixTransient):
-		if len(k) > lenPT {
-			return transientType, k[lenPT:]
-		}
-	case strings.HasPrefix(k, PrefixPersistent):
-		if len(k) > lenPP {
-			return persistentType, k[lenPP:]
-		}
-	}
-	return invalidType, k
 }


### PR DESCRIPTION
The metainfo module is designed to store key-value pairs in the context. The underlying data structure is a linked list that stores a key-value pair in each node and attaches the node to the context.

When the number of key-value pair grows up, the cost for searching a key increases too. And if the length of the linked list reaches a certain value, querying a key may cause the stack to grow since the `context.Context` queries key recursively.

By changing the underlying data structure from linked list to slices and store all data at each node, we can reduce memory allocation in most operations while improve performance. Especially for methods that do some 'batch' operation.

The below shows the benchmark comparison before and after the modification.

```
benchmark                                             old ns/op     new ns/op     delta
BenchmarkHTTPHeaderToCGIVariable-8                    239           236           -1.21%
BenchmarkCGIVariableToHTTPHeader-8                    242           255           +5.55%
BenchmarkFromHTTPHeader/FromHTTPHeader-10-8           2700          2255          -16.48%
BenchmarkFromHTTPHeader/FromHTTPHeader-20-8           5573          4933          -11.48%
BenchmarkFromHTTPHeader/FromHTTPHeader-50-8           14998         10654         -28.96%
BenchmarkFromHTTPHeader/FromHTTPHeader-100-8          31882         21210         -33.47%
BenchmarkToHTTPHeader/ToHTTPHeader-10-8               8527          7436          -12.79%
BenchmarkToHTTPHeader/ToHTTPHeader-20-8               18062         14526         -19.58%
BenchmarkToHTTPHeader/ToHTTPHeader-50-8               42186         34220         -18.88%
BenchmarkToHTTPHeader/ToHTTPHeader-100-8              85622         66174         -22.71%
BenchmarkAll/TransferForward_10-8                     1491          180           -87.91%
BenchmarkAll/TransferForward_20-8                     2848          172           -93.95%
BenchmarkAll/TransferForward_50-8                     7252          182           -97.49%
BenchmarkAll/TransferForward_100-8                    14185         161           -98.87%
BenchmarkAll/GetValue_10-8                            90.9          53.3          -41.34%
BenchmarkAll/GetValue_20-8                            112           58.1          -48.03%
BenchmarkAll/GetValue_50-8                            269           124           -53.90%
BenchmarkAll/GetValue_100-8                           563           244           -56.69%
BenchmarkAll/GetAllValues_10-8                        1524          820           -46.21%
BenchmarkAll/GetAllValues_20-8                        3608          1566          -56.60%
BenchmarkAll/GetAllValues_50-8                        8332          3676          -55.88%
BenchmarkAll/GetAllValues_100-8                       17419         7219          -58.56%
BenchmarkAll/WithValue_10-8                           152           191           +25.59%
BenchmarkAll/WithValue_20-8                           148           200           +34.98%
BenchmarkAll/WithValue_50-8                           157           239           +52.52%
BenchmarkAll/WithValue_100-8                          150           283           +89.44%
BenchmarkAll/WithValueAcc_10-8                        432           131           -69.59%
BenchmarkAll/WithValueAcc_20-8                        354           145           -59.15%
BenchmarkAll/WithValueAcc_50-8                        316           318           +0.92%
BenchmarkAll/WithValueAcc_100-8                       344           653           +89.99%
BenchmarkAll/DelValue_10-8                            153           39.2          -74.43%
BenchmarkAll/DelValue_20-8                            148           42.7          -71.11%
BenchmarkAll/DelValue_50-8                            148           76.0          -48.77%
BenchmarkAll/DelValue_100-8                           146           112           -22.99%
BenchmarkAll/GetPersistentValue_10-8                  86.7          53.6          -38.23%
BenchmarkAll/GetPersistentValue_20-8                  105           59.1          -43.70%
BenchmarkAll/GetPersistentValue_50-8                  267           127           -52.66%
BenchmarkAll/GetPersistentValue_100-8                 563           238           -57.64%
BenchmarkAll/GetAllPersistentValues_10-8              1515          835           -44.87%
BenchmarkAll/GetAllPersistentValues_20-8              3509          1622          -53.78%
BenchmarkAll/GetAllPersistentValues_50-8              8431          3753          -55.49%
BenchmarkAll/GetAllPersistentValues_100-8             17206         7305          -57.54%
BenchmarkAll/WithPersistentValue_10-8                 146           183           +25.09%
BenchmarkAll/WithPersistentValue_20-8                 149           196           +31.17%
BenchmarkAll/WithPersistentValue_50-8                 171           226           +31.97%
BenchmarkAll/WithPersistentValue_100-8                147           267           +81.48%
BenchmarkAll/WithPersistentValueAcc_10-8              386           120           -68.89%
BenchmarkAll/WithPersistentValueAcc_20-8              333           136           -59.29%
BenchmarkAll/WithPersistentValueAcc_50-8              314           314           -0.16%
BenchmarkAll/WithPersistentValueAcc_100-8             314           674           +114.24%
BenchmarkAll/DelPersistentValue_10-8                  154           28.4          -81.64%
BenchmarkAll/DelPersistentValue_20-8                  154           35.0          -77.27%
BenchmarkAll/DelPersistentValue_50-8                  156           66.6          -57.39%
BenchmarkAll/DelPersistentValue_100-8                 163           105           -35.91%
BenchmarkAll/SaveMetaInfoToMap_10-8                   9876          6644          -32.73%
BenchmarkAll/SaveMetaInfoToMap_20-8                   20477         13679         -33.20%
BenchmarkAll/SaveMetaInfoToMap_50-8                   48650         31190         -35.89%
BenchmarkAll/SaveMetaInfoToMap_100-8                  98006         64546         -34.14%
BenchmarkAll/SetMetaInfoFromMap_10-8                  4039          3079          -23.77%
BenchmarkAll/SetMetaInfoFromMap_20-8                  7958          4872          -38.78%
BenchmarkAll/SetMetaInfoFromMap_50-8                  20780         8985          -56.76%
BenchmarkAll/SetMetaInfoFromMap_100-8                 39122         17617         -54.97%
BenchmarkAllParallel/TransferForward_10-8             551           65.4          -88.13%
BenchmarkAllParallel/TransferForward_20-8             1116          62.2          -94.43%
BenchmarkAllParallel/TransferForward_50-8             3059          65.2          -97.87%
BenchmarkAllParallel/TransferForward_100-8            6442          65.1          -98.99%
BenchmarkAllParallel/GetValue_10-8                    11.4          7.62          -33.08%
BenchmarkAllParallel/GetValue_20-8                    14.5          10.0          -30.99%
BenchmarkAllParallel/GetValue_50-8                    34.4          24.0          -30.13%
BenchmarkAllParallel/GetValue_100-8                   70.2          44.1          -37.25%
BenchmarkAllParallel/GetAllValues_10-8                566           370           -34.73%
BenchmarkAllParallel/GetAllValues_20-8                1501          658           -56.13%
BenchmarkAllParallel/GetAllValues_50-8                3277          1360          -58.50%
BenchmarkAllParallel/GetAllValues_100-8               7007          3402          -51.45%
BenchmarkAllParallel/WithValue_10-8                   63.2          102           +60.58%
BenchmarkAllParallel/WithValue_20-8                   67.7          100.0         +47.76%
BenchmarkAllParallel/WithValue_50-8                   59.9          142           +136.81%
BenchmarkAllParallel/WithValue_100-8                  57.8          258           +347.00%
BenchmarkAllParallel/WithValueAcc_10-8                107           17.6          -83.48%
BenchmarkAllParallel/WithValueAcc_20-8                98.3          23.2          -76.35%
BenchmarkAllParallel/WithValueAcc_50-8                105           53.2          -49.47%
BenchmarkAllParallel/WithValueAcc_100-8               80.2          97.5          +21.59%
BenchmarkAllParallel/DelValue_10-8                    64.8          5.24          -91.90%
BenchmarkAllParallel/DelValue_20-8                    71.0          6.15          -91.33%
BenchmarkAllParallel/DelValue_50-8                    66.0          10.3          -84.38%
BenchmarkAllParallel/DelValue_100-8                   61.0          17.7          -70.94%
BenchmarkAllParallel/GetPersistentValue_10-8          11.0          7.76          -29.55%
BenchmarkAllParallel/GetPersistentValue_20-8          15.1          8.12          -46.29%
BenchmarkAllParallel/GetPersistentValue_50-8          34.2          22.0          -35.65%
BenchmarkAllParallel/GetPersistentValue_100-8         73.0          37.3          -48.94%
BenchmarkAllParallel/GetAllPersistentValues_10-8      659           371           -43.65%
BenchmarkAllParallel/GetAllPersistentValues_20-8      1442          739           -48.77%
BenchmarkAllParallel/GetAllPersistentValues_50-8      3575          1632          -54.35%
BenchmarkAllParallel/GetAllPersistentValues_100-8     7911          3348          -57.68%
BenchmarkAllParallel/WithPersistentValue_10-8         65.4          158           +141.51%
BenchmarkAllParallel/WithPersistentValue_20-8         63.5          151           +137.33%
BenchmarkAllParallel/WithPersistentValue_50-8         67.5          324           +380.31%
BenchmarkAllParallel/WithPersistentValue_100-8        67.0          591           +782.04%
BenchmarkAllParallel/WithPersistentValueAcc_10-8      88.7          15.4          -82.63%
BenchmarkAllParallel/WithPersistentValueAcc_20-8      84.6          20.9          -75.30%
BenchmarkAllParallel/WithPersistentValueAcc_50-8      99.9          55.9          -44.00%
BenchmarkAllParallel/WithPersistentValueAcc_100-8     85.9          119           +38.07%
BenchmarkAllParallel/DelPersistentValue_10-8          55.1          3.67          -93.34%
BenchmarkAllParallel/DelPersistentValue_20-8          60.0          4.61          -92.30%
BenchmarkAllParallel/DelPersistentValue_50-8          55.9          8.42          -84.95%
BenchmarkAllParallel/DelPersistentValue_100-8         61.7          14.2          -76.92%
BenchmarkAllParallel/SaveMetaInfoToMap_10-8           3369          2633          -21.85%
BenchmarkAllParallel/SaveMetaInfoToMap_20-8           7440          4813          -35.31%
BenchmarkAllParallel/SaveMetaInfoToMap_50-8           17721         12889         -27.27%
BenchmarkAllParallel/SaveMetaInfoToMap_100-8          38440         29002         -24.55%
BenchmarkAllParallel/SetMetaInfoFromMap_10-8          1334          1228          -7.95%
BenchmarkAllParallel/SetMetaInfoFromMap_20-8          2634          2100          -20.27%
BenchmarkAllParallel/SetMetaInfoFromMap_50-8          6518          4416          -32.25%
BenchmarkAllParallel/SetMetaInfoFromMap_100-8         14108         8860          -37.20%

benchmark                                             old allocs     new allocs     delta
BenchmarkHTTPHeaderToCGIVariable-8                    2              2              +0.00%
BenchmarkCGIVariableToHTTPHeader-8                    2              2              +0.00%
BenchmarkFromHTTPHeader/FromHTTPHeader-10-8           26             17             -34.62%
BenchmarkFromHTTPHeader/FromHTTPHeader-20-8           56             31             -44.64%
BenchmarkFromHTTPHeader/FromHTTPHeader-50-8           146            63             -56.85%
BenchmarkFromHTTPHeader/FromHTTPHeader-100-8          296            115            -61.15%
BenchmarkToHTTPHeader/ToHTTPHeader-10-8               46             44             -4.35%
BenchmarkToHTTPHeader/ToHTTPHeader-20-8               88             84             -4.55%
BenchmarkToHTTPHeader/ToHTTPHeader-50-8               214            206            -3.74%
BenchmarkToHTTPHeader/ToHTTPHeader-100-8              422            409            -3.08%
BenchmarkAll/TransferForward_10-8                     21             2              -90.48%
BenchmarkAll/TransferForward_20-8                     41             2              -95.12%
BenchmarkAll/TransferForward_50-8                     101            2              -98.02%
BenchmarkAll/TransferForward_100-8                    201            2              -99.00%
BenchmarkAll/GetValue_10-8                            0              0              +0.00%
BenchmarkAll/GetValue_20-8                            0              0              +0.00%
BenchmarkAll/GetValue_50-8                            0              0              +0.00%
BenchmarkAll/GetValue_100-8                           0              0              +0.00%
BenchmarkAll/GetAllValues_10-8                        3              2              -33.33%
BenchmarkAll/GetAllValues_20-8                        4              2              -50.00%
BenchmarkAll/GetAllValues_50-8                        7              3              -57.14%
BenchmarkAll/GetAllValues_100-8                       11             4              -63.64%
BenchmarkAll/WithValue_10-8                           2              2              +0.00%
BenchmarkAll/WithValue_20-8                           2              2              +0.00%
BenchmarkAll/WithValue_50-8                           2              2              +0.00%
BenchmarkAll/WithValue_100-8                          2              2              +0.00%
BenchmarkAll/WithValueAcc_10-8                        2              0              -100.00%
BenchmarkAll/WithValueAcc_20-8                        2              0              -100.00%
BenchmarkAll/WithValueAcc_50-8                        2              0              -100.00%
BenchmarkAll/WithValueAcc_100-8                       2              0              -100.00%
BenchmarkAll/DelValue_10-8                            2              0              -100.00%
BenchmarkAll/DelValue_20-8                            2              0              -100.00%
BenchmarkAll/DelValue_50-8                            2              0              -100.00%
BenchmarkAll/DelValue_100-8                           2              0              -100.00%
BenchmarkAll/GetPersistentValue_10-8                  0              0              +0.00%
BenchmarkAll/GetPersistentValue_20-8                  0              0              +0.00%
BenchmarkAll/GetPersistentValue_50-8                  0              0              +0.00%
BenchmarkAll/GetPersistentValue_100-8                 0              0              +0.00%
BenchmarkAll/GetAllPersistentValues_10-8              3              2              -33.33%
BenchmarkAll/GetAllPersistentValues_20-8              4              2              -50.00%
BenchmarkAll/GetAllPersistentValues_50-8              7              3              -57.14%
BenchmarkAll/GetAllPersistentValues_100-8             11             4              -63.64%
BenchmarkAll/WithPersistentValue_10-8                 2              2              +0.00%
BenchmarkAll/WithPersistentValue_20-8                 2              2              +0.00%
BenchmarkAll/WithPersistentValue_50-8                 2              2              +0.00%
BenchmarkAll/WithPersistentValue_100-8                2              2              +0.00%
BenchmarkAll/WithPersistentValueAcc_10-8              2              0              -100.00%
BenchmarkAll/WithPersistentValueAcc_20-8              2              0              -100.00%
BenchmarkAll/WithPersistentValueAcc_50-8              2              0              -100.00%
BenchmarkAll/WithPersistentValueAcc_100-8             2              0              -100.00%
BenchmarkAll/DelPersistentValue_10-8                  2              0              -100.00%
BenchmarkAll/DelPersistentValue_20-8                  2              0              -100.00%
BenchmarkAll/DelPersistentValue_50-8                  2              0              -100.00%
BenchmarkAll/DelPersistentValue_100-8                 2              0              -100.00%
BenchmarkAll/SaveMetaInfoToMap_10-8                   49             28             -42.86%
BenchmarkAll/SaveMetaInfoToMap_20-8                   94             50             -46.81%
BenchmarkAll/SaveMetaInfoToMap_50-8                   224            118            -47.32%
BenchmarkAll/SaveMetaInfoToMap_100-8                  438            226            -48.40%
BenchmarkAll/SetMetaInfoFromMap_10-8                  40             12             -70.00%
BenchmarkAll/SetMetaInfoFromMap_20-8                  80             14             -82.50%
BenchmarkAll/SetMetaInfoFromMap_50-8                  200            16             -92.00%
BenchmarkAll/SetMetaInfoFromMap_100-8                 400            18             -95.50%
BenchmarkAllParallel/TransferForward_10-8             21             2              -90.48%
BenchmarkAllParallel/TransferForward_20-8             41             2              -95.12%
BenchmarkAllParallel/TransferForward_50-8             101            2              -98.02%
BenchmarkAllParallel/TransferForward_100-8            201            2              -99.00%
BenchmarkAllParallel/GetValue_10-8                    0              0              +0.00%
BenchmarkAllParallel/GetValue_20-8                    0              0              +0.00%
BenchmarkAllParallel/GetValue_50-8                    0              0              +0.00%
BenchmarkAllParallel/GetValue_100-8                   0              0              +0.00%
BenchmarkAllParallel/GetAllValues_10-8                3              2              -33.33%
BenchmarkAllParallel/GetAllValues_20-8                4              2              -50.00%
BenchmarkAllParallel/GetAllValues_50-8                7              3              -57.14%
BenchmarkAllParallel/GetAllValues_100-8               11             4              -63.64%
BenchmarkAllParallel/WithValue_10-8                   2              2              +0.00%
BenchmarkAllParallel/WithValue_20-8                   2              2              +0.00%
BenchmarkAllParallel/WithValue_50-8                   2              2              +0.00%
BenchmarkAllParallel/WithValue_100-8                  2              2              +0.00%
BenchmarkAllParallel/WithValueAcc_10-8                2              0              -100.00%
BenchmarkAllParallel/WithValueAcc_20-8                2              0              -100.00%
BenchmarkAllParallel/WithValueAcc_50-8                2              0              -100.00%
BenchmarkAllParallel/WithValueAcc_100-8               2              0              -100.00%
BenchmarkAllParallel/DelValue_10-8                    2              0              -100.00%
BenchmarkAllParallel/DelValue_20-8                    2              0              -100.00%
BenchmarkAllParallel/DelValue_50-8                    2              0              -100.00%
BenchmarkAllParallel/DelValue_100-8                   2              0              -100.00%
BenchmarkAllParallel/GetPersistentValue_10-8          0              0              +0.00%
BenchmarkAllParallel/GetPersistentValue_20-8          0              0              +0.00%
BenchmarkAllParallel/GetPersistentValue_50-8          0              0              +0.00%
BenchmarkAllParallel/GetPersistentValue_100-8         0              0              +0.00%
BenchmarkAllParallel/GetAllPersistentValues_10-8      3              2              -33.33%
BenchmarkAllParallel/GetAllPersistentValues_20-8      4              2              -50.00%
BenchmarkAllParallel/GetAllPersistentValues_50-8      7              3              -57.14%
BenchmarkAllParallel/GetAllPersistentValues_100-8     11             4              -63.64%
BenchmarkAllParallel/WithPersistentValue_10-8         2              2              +0.00%
BenchmarkAllParallel/WithPersistentValue_20-8         2              2              +0.00%
BenchmarkAllParallel/WithPersistentValue_50-8         2              2              +0.00%
BenchmarkAllParallel/WithPersistentValue_100-8        2              2              +0.00%
BenchmarkAllParallel/WithPersistentValueAcc_10-8      2              0              -100.00%
BenchmarkAllParallel/WithPersistentValueAcc_20-8      2              0              -100.00%
BenchmarkAllParallel/WithPersistentValueAcc_50-8      2              0              -100.00%
BenchmarkAllParallel/WithPersistentValueAcc_100-8     2              0              -100.00%
BenchmarkAllParallel/DelPersistentValue_10-8          2              0              -100.00%
BenchmarkAllParallel/DelPersistentValue_20-8          2              0              -100.00%
BenchmarkAllParallel/DelPersistentValue_50-8          2              0              -100.00%
BenchmarkAllParallel/DelPersistentValue_100-8         2              0              -100.00%
BenchmarkAllParallel/SaveMetaInfoToMap_10-8           49             28             -42.86%
BenchmarkAllParallel/SaveMetaInfoToMap_20-8           94             50             -46.81%
BenchmarkAllParallel/SaveMetaInfoToMap_50-8           224            117            -47.77%
BenchmarkAllParallel/SaveMetaInfoToMap_100-8          438            226            -48.40%
BenchmarkAllParallel/SetMetaInfoFromMap_10-8          40             12             -70.00%
BenchmarkAllParallel/SetMetaInfoFromMap_20-8          80             14             -82.50%
BenchmarkAllParallel/SetMetaInfoFromMap_50-8          200            16             -92.00%
BenchmarkAllParallel/SetMetaInfoFromMap_100-8         400            18             -95.50%

benchmark                                             old bytes     new bytes     delta
BenchmarkHTTPHeaderToCGIVariable-8                    48            48            +0.00%
BenchmarkCGIVariableToHTTPHeader-8                    48            48            +0.00%
BenchmarkFromHTTPHeader/FromHTTPHeader-10-8           825           617           -25.21%
BenchmarkFromHTTPHeader/FromHTTPHeader-20-8           1817          2185          +20.25%
BenchmarkFromHTTPHeader/FromHTTPHeader-50-8           4826          4365          -9.55%
BenchmarkFromHTTPHeader/FromHTTPHeader-100-8          9831          8662          -11.89%
BenchmarkToHTTPHeader/ToHTTPHeader-10-8               2636          2060          -21.85%
BenchmarkToHTTPHeader/ToHTTPHeader-20-8               5976          4094          -31.49%
BenchmarkToHTTPHeader/ToHTTPHeader-50-8               14069         9470          -32.69%
BenchmarkToHTTPHeader/ToHTTPHeader-100-8              29006         18900         -34.84%
BenchmarkAll/TransferForward_10-8                     1008          128           -87.30%
BenchmarkAll/TransferForward_20-8                     1968          128           -93.50%
BenchmarkAll/TransferForward_50-8                     4848          128           -97.36%
BenchmarkAll/TransferForward_100-8                    9648          128           -98.67%
BenchmarkAll/GetValue_10-8                            0             0             +0.00%
BenchmarkAll/GetValue_20-8                            0             0             +0.00%
BenchmarkAll/GetValue_50-8                            0             0             +0.00%
BenchmarkAll/GetValue_100-8                           0             0             +0.00%
BenchmarkAll/GetAllValues_10-8                        918           630           -31.37%
BenchmarkAll/GetAllValues_20-8                        2187          1247          -42.98%
BenchmarkAll/GetAllValues_50-8                        5035          2735          -45.68%
BenchmarkAll/GetAllValues_100-8                       10508         5449          -48.14%
BenchmarkAll/WithValue_10-8                           96            128           +33.33%
BenchmarkAll/WithValue_20-8                           96            128           +33.33%
BenchmarkAll/WithValue_50-8                           96            128           +33.33%
BenchmarkAll/WithValue_100-8                          96            128           +33.33%
BenchmarkAll/WithValueAcc_10-8                        96            0             -100.00%
BenchmarkAll/WithValueAcc_20-8                        96            0             -100.00%
BenchmarkAll/WithValueAcc_50-8                        96            0             -100.00%
BenchmarkAll/WithValueAcc_100-8                       96            0             -100.00%
BenchmarkAll/DelValue_10-8                            96            0             -100.00%
BenchmarkAll/DelValue_20-8                            96            0             -100.00%
BenchmarkAll/DelValue_50-8                            96            0             -100.00%
BenchmarkAll/DelValue_100-8                           96            0             -100.00%
BenchmarkAll/GetPersistentValue_10-8                  0             0             +0.00%
BenchmarkAll/GetPersistentValue_20-8                  0             0             +0.00%
BenchmarkAll/GetPersistentValue_50-8                  0             0             +0.00%
BenchmarkAll/GetPersistentValue_100-8                 0             0             +0.00%
BenchmarkAll/GetAllPersistentValues_10-8              918           630           -31.37%
BenchmarkAll/GetAllPersistentValues_20-8              2187          1247          -42.98%
BenchmarkAll/GetAllPersistentValues_50-8              5036          2735          -45.69%
BenchmarkAll/GetAllPersistentValues_100-8             10505         5450          -48.12%
BenchmarkAll/WithPersistentValue_10-8                 96            128           +33.33%
BenchmarkAll/WithPersistentValue_20-8                 96            128           +33.33%
BenchmarkAll/WithPersistentValue_50-8                 96            128           +33.33%
BenchmarkAll/WithPersistentValue_100-8                96            128           +33.33%
BenchmarkAll/WithPersistentValueAcc_10-8              96            0             -100.00%
BenchmarkAll/WithPersistentValueAcc_20-8              96            0             -100.00%
BenchmarkAll/WithPersistentValueAcc_50-8              96            0             -100.00%
BenchmarkAll/WithPersistentValueAcc_100-8             96            0             -100.00%
BenchmarkAll/DelPersistentValue_10-8                  96            0             -100.00%
BenchmarkAll/DelPersistentValue_20-8                  96            0             -100.00%
BenchmarkAll/DelPersistentValue_50-8                  96            0             -100.00%
BenchmarkAll/DelPersistentValue_100-8                 96            0             -100.00%
BenchmarkAll/SaveMetaInfoToMap_10-8                   5176          3720          -28.13%
BenchmarkAll/SaveMetaInfoToMap_20-8                   11748         8023          -31.71%
BenchmarkAll/SaveMetaInfoToMap_50-8                   27492         18172         -33.90%
BenchmarkAll/SaveMetaInfoToMap_100-8                  56280         36658         -34.86%
BenchmarkAll/SetMetaInfoFromMap_10-8                  1920          2112          +10.00%
BenchmarkAll/SetMetaInfoFromMap_20-8                  3840          4160          +8.33%
BenchmarkAll/SetMetaInfoFromMap_50-8                  9600          8256          -14.00%
BenchmarkAll/SetMetaInfoFromMap_100-8                 19200         16448         -14.33%
BenchmarkAllParallel/TransferForward_10-8             1008          128           -87.30%
BenchmarkAllParallel/TransferForward_20-8             1968          128           -93.50%
BenchmarkAllParallel/TransferForward_50-8             4848          128           -97.36%
BenchmarkAllParallel/TransferForward_100-8            9648          128           -98.67%
BenchmarkAllParallel/GetValue_10-8                    0             0             +0.00%
BenchmarkAllParallel/GetValue_20-8                    0             0             +0.00%
BenchmarkAllParallel/GetValue_50-8                    0             0             +0.00%
BenchmarkAllParallel/GetValue_100-8                   0             0             +0.00%
BenchmarkAllParallel/GetAllValues_10-8                918           630           -31.37%
BenchmarkAllParallel/GetAllValues_20-8                2187          1247          -42.98%
BenchmarkAllParallel/GetAllValues_50-8                5034          2734          -45.69%
BenchmarkAllParallel/GetAllValues_100-8               10507         5449          -48.14%
BenchmarkAllParallel/WithValue_10-8                   96            128           +33.33%
BenchmarkAllParallel/WithValue_20-8                   96            128           +33.33%
BenchmarkAllParallel/WithValue_50-8                   96            128           +33.33%
BenchmarkAllParallel/WithValue_100-8                  96            128           +33.33%
BenchmarkAllParallel/WithValueAcc_10-8                96            0             -100.00%
BenchmarkAllParallel/WithValueAcc_20-8                96            0             -100.00%
BenchmarkAllParallel/WithValueAcc_50-8                96            0             -100.00%
BenchmarkAllParallel/WithValueAcc_100-8               96            0             -100.00%
BenchmarkAllParallel/DelValue_10-8                    96            0             -100.00%
BenchmarkAllParallel/DelValue_20-8                    96            0             -100.00%
BenchmarkAllParallel/DelValue_50-8                    96            0             -100.00%
BenchmarkAllParallel/DelValue_100-8                   96            0             -100.00%
BenchmarkAllParallel/GetPersistentValue_10-8          0             0             +0.00%
BenchmarkAllParallel/GetPersistentValue_20-8          0             0             +0.00%
BenchmarkAllParallel/GetPersistentValue_50-8          0             0             +0.00%
BenchmarkAllParallel/GetPersistentValue_100-8         0             0             +0.00%
BenchmarkAllParallel/GetAllPersistentValues_10-8      918           630           -31.37%
BenchmarkAllParallel/GetAllPersistentValues_20-8      2188          1247          -43.01%
BenchmarkAllParallel/GetAllPersistentValues_50-8      5035          2734          -45.70%
BenchmarkAllParallel/GetAllPersistentValues_100-8     10505         5449          -48.13%
BenchmarkAllParallel/WithPersistentValue_10-8         96            128           +33.33%
BenchmarkAllParallel/WithPersistentValue_20-8         96            128           +33.33%
BenchmarkAllParallel/WithPersistentValue_50-8         96            128           +33.33%
BenchmarkAllParallel/WithPersistentValue_100-8        96            128           +33.33%
BenchmarkAllParallel/WithPersistentValueAcc_10-8      96            0             -100.00%
BenchmarkAllParallel/WithPersistentValueAcc_20-8      96            0             -100.00%
BenchmarkAllParallel/WithPersistentValueAcc_50-8      96            0             -100.00%
BenchmarkAllParallel/WithPersistentValueAcc_100-8     96            0             -100.00%
BenchmarkAllParallel/DelPersistentValue_10-8          96            0             -100.00%
BenchmarkAllParallel/DelPersistentValue_20-8          96            0             -100.00%
BenchmarkAllParallel/DelPersistentValue_50-8          96            0             -100.00%
BenchmarkAllParallel/DelPersistentValue_100-8         96            0             -100.00%
BenchmarkAllParallel/SaveMetaInfoToMap_10-8           5176          3720          -28.13%
BenchmarkAllParallel/SaveMetaInfoToMap_20-8           11748         8026          -31.68%
BenchmarkAllParallel/SaveMetaInfoToMap_50-8           27491         18164         -33.93%
BenchmarkAllParallel/SaveMetaInfoToMap_100-8          56283         36660         -34.86%
BenchmarkAllParallel/SetMetaInfoFromMap_10-8          1920          2112          +10.00%
BenchmarkAllParallel/SetMetaInfoFromMap_20-8          3840          4160          +8.33%
BenchmarkAllParallel/SetMetaInfoFromMap_50-8          9600          8256          -14.00%
BenchmarkAllParallel/SetMetaInfoFromMap_100-8         19200         16448         -14.33%
```