### PR TITLE
feat: skipset and skipmap support optional array

### DIFF
--- a/collection/skipmap/oparray.go
+++ b/collection/skipmap/oparray.go
@@ -1,0 +1,60 @@
+// Copyright 2021 ByteDance Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package skipmap
+
+import (
+	"sync/atomic"
+	"unsafe"
+)
+
+const (
+	op1 = 4
+	op2 = maxLevel - op1
+)
+
+type optionalArray struct {
+	base  [op1]unsafe.Pointer
+	extra *([op2]unsafe.Pointer)
+}
+
+func (a *optionalArray) load(i int) unsafe.Pointer {
+	if i < op1 {
+		return a.base[i]
+	}
+	return a.extra[i-op1]
+}
+
+func (a *optionalArray) store(i int, p unsafe.Pointer) {
+	if i < op1 {
+		a.base[i] = p
+		return
+	}
+	a.extra[i-op1] = p
+}
+
+func (a *optionalArray) atomicLoad(i int) unsafe.Pointer {
+	if i < op1 {
+		return atomic.LoadPointer(&a.base[i])
+	}
+	return atomic.LoadPointer(&a.extra[i-op1])
+}
+
+func (a *optionalArray) atomicStore(i int, p unsafe.Pointer) {
+	if i < op1 {
+		atomic.StorePointer(&a.base[i], p)
+		return
+	}
+	atomic.StorePointer(&a.extra[i-op1], p)
+}

--- a/collection/skipmap/oparry_test.go
+++ b/collection/skipmap/oparry_test.go
@@ -1,0 +1,64 @@
+// Copyright 2021 ByteDance Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package skipmap
+
+import (
+	"testing"
+	"unsafe"
+
+	"github.com/bytedance/gopkg/lang/fastrand"
+)
+
+type dummy struct {
+	data optionalArray
+}
+
+func TestOpArray(t *testing.T) {
+	n := new(dummy)
+	n.data.extra = new([op2]unsafe.Pointer)
+
+	var array [maxLevel]unsafe.Pointer
+	for i := 0; i < maxLevel; i++ {
+		value := unsafe.Pointer(&dummy{})
+		array[i] = value
+		n.data.store(i, value)
+	}
+
+	for i := 0; i < maxLevel; i++ {
+		if array[i] != n.data.load(i) || array[i] != n.data.atomicLoad(i) {
+			t.Fatal(i, array[i], n.data.load(i))
+		}
+	}
+
+	for i := 0; i < 1000; i++ {
+		r := int(fastrand.Uint32n(maxLevel))
+		value := unsafe.Pointer(&dummy{})
+		if i%100 == 0 {
+			value = nil
+		}
+		array[r] = value
+		if fastrand.Uint32n(2) == 0 {
+			n.data.store(r, value)
+		} else {
+			n.data.atomicStore(r, value)
+		}
+	}
+
+	for i := 0; i < maxLevel; i++ {
+		if array[i] != n.data.load(i) || array[i] != n.data.atomicLoad(i) {
+			t.Fatal(i, array[i], n.data.load(i))
+		}
+	}
+}

--- a/collection/skipmap/types_gen.go
+++ b/collection/skipmap/types_gen.go
@@ -125,10 +125,8 @@ func replaceString(data string) string {
 	score uint64`, -1)
 
 	data = strings.Replace(data,
+		`&int64Node{`,
 		`&int64Node{
-		key:  key,`,
-		`&int64Node{
-		key:  key,
 		score: hash(key),`, -1)
 
 	// Refactor comparsion.

--- a/collection/skipset/oparry.go
+++ b/collection/skipset/oparry.go
@@ -1,0 +1,60 @@
+// Copyright 2021 ByteDance Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package skipset
+
+import (
+	"sync/atomic"
+	"unsafe"
+)
+
+const (
+	op1 = 4
+	op2 = maxLevel - op1
+)
+
+type optionalArray struct {
+	base  [op1]unsafe.Pointer
+	extra *([op2]unsafe.Pointer)
+}
+
+func (a *optionalArray) load(i int) unsafe.Pointer {
+	if i < op1 {
+		return a.base[i]
+	}
+	return a.extra[i-op1]
+}
+
+func (a *optionalArray) store(i int, p unsafe.Pointer) {
+	if i < op1 {
+		a.base[i] = p
+		return
+	}
+	a.extra[i-op1] = p
+}
+
+func (a *optionalArray) atomicLoad(i int) unsafe.Pointer {
+	if i < op1 {
+		return atomic.LoadPointer(&a.base[i])
+	}
+	return atomic.LoadPointer(&a.extra[i-op1])
+}
+
+func (a *optionalArray) atomicStore(i int, p unsafe.Pointer) {
+	if i < op1 {
+		atomic.StorePointer(&a.base[i], p)
+		return
+	}
+	atomic.StorePointer(&a.extra[i-op1], p)
+}

--- a/collection/skipset/oparry_test.go
+++ b/collection/skipset/oparry_test.go
@@ -1,0 +1,64 @@
+// Copyright 2021 ByteDance Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package skipset
+
+import (
+	"testing"
+	"unsafe"
+
+	"github.com/bytedance/gopkg/lang/fastrand"
+)
+
+type dummy struct {
+	data optionalArray
+}
+
+func TestOpArray(t *testing.T) {
+	n := new(dummy)
+	n.data.extra = new([op2]unsafe.Pointer)
+
+	var array [maxLevel]unsafe.Pointer
+	for i := 0; i < maxLevel; i++ {
+		value := unsafe.Pointer(&dummy{})
+		array[i] = value
+		n.data.store(i, value)
+	}
+
+	for i := 0; i < maxLevel; i++ {
+		if array[i] != n.data.load(i) || array[i] != n.data.atomicLoad(i) {
+			t.Fatal(i, array[i], n.data.load(i))
+		}
+	}
+
+	for i := 0; i < 1000; i++ {
+		r := int(fastrand.Uint32n(maxLevel))
+		value := unsafe.Pointer(&dummy{})
+		if i%100 == 0 {
+			value = nil
+		}
+		array[r] = value
+		if fastrand.Uint32n(2) == 0 {
+			n.data.store(r, value)
+		} else {
+			n.data.atomicStore(r, value)
+		}
+	}
+
+	for i := 0; i < maxLevel; i++ {
+		if array[i] != n.data.load(i) || array[i] != n.data.atomicLoad(i) {
+			t.Fatal(i, array[i], n.data.load(i))
+		}
+	}
+}

--- a/collection/skipset/types_gen.go
+++ b/collection/skipset/types_gen.go
@@ -123,10 +123,8 @@ func replaceString(data string) string {
 	score uint64`, -1)
 
 	data = strings.Replace(data,
-		`return &int64Node{
-		value: value,`,
-		`return &int64Node{
-		value: value,
+		`&int64Node{`,
+		`&int64Node{
 		score: hash(value),`, -1)
 
 	// Refactor comparsion.


### PR DESCRIPTION
```name                                             old time/op    new time/op    delta
Add/skipset-16                                      107ns ± 9%      82ns ±13%   -23.67%  (p=0.000 n=19+19)
Add/sync.Map-16                                     697ns ± 7%     695ns ± 5%      ~     (p=0.758 n=20+20)
Contains100Hits/skipset-16                         11.4ns ±28%     9.7ns ±22%   -14.72%  (p=0.000 n=19+18)
Contains100Hits/sync.Map-16                        16.2ns ±19%    15.9ns ±16%      ~     (p=0.394 n=20+20)
Contains50Hits/skipset-16                          11.8ns ±12%    10.5ns ±28%   -10.80%  (p=0.008 n=18+20)
Contains50Hits/sync.Map-16                         14.9ns ±14%    14.2ns ±19%      ~     (p=0.091 n=20+19)
ContainsNoHits/skipset-16                          11.6ns ±16%    10.3ns ±17%   -11.47%  (p=0.000 n=19+20)
ContainsNoHits/sync.Map-16                         12.8ns ±22%    12.3ns ±20%      ~     (p=0.231 n=19+19)
50Add50Contains/skipset-16                         59.2ns ±11%    44.9ns ±17%   -24.10%  (p=0.000 n=18+19)
50Add50Contains/sync.Map-16                         592ns ± 8%     580ns ± 7%      ~     (p=0.117 n=19+18)
30Add70Contains/skipset-16                         47.9ns ±19%    36.2ns ±22%   -24.38%  (p=0.000 n=19+19)
30Add70Contains/sync.Map-16                         611ns ± 4%     610ns ± 7%      ~     (p=0.829 n=19+20)
1Remove9Add90Contains/skipset-16                   33.4ns ±15%    25.4ns ±18%   -24.13%  (p=0.000 n=19+18)
1Remove9Add90Contains/sync.Map-16                   507ns ± 7%     508ns ± 6%      ~     (p=0.835 n=19+20)
1Range9Remove90Add900Contains/skipset-16           36.0ns ±13%    27.6ns ±19%   -23.40%  (p=0.000 n=16+19)
1Range9Remove90Add900Contains/sync.Map-16          1.19µs ±16%    1.18µs ±14%      ~     (p=0.616 n=20+20)
StringAdd/skipset-16                                143ns ± 8%     120ns ±13%   -16.15%  (p=0.000 n=19+19)
StringAdd/sync.Map-16                               901ns ± 5%     892ns ± 3%      ~     (p=0.361 n=20+19)
StringContains50Hits/skipset-16                    19.6ns ±31%    18.4ns ±26%      ~     (p=0.292 n=20+20)
StringContains50Hits/sync.Map-16                   19.7ns ±22%    19.2ns ±10%      ~     (p=0.641 n=20+17)
String30Add70Contains/skipset-16                   67.9ns ±19%    56.1ns ±16%   -17.42%  (p=0.000 n=20+18)
String30Add70Contains/sync.Map-16                   783ns ± 5%     779ns ± 7%      ~     (p=0.688 n=16+20)
String1Remove9Add90Contains/skipset-16             39.5ns ±21%    31.0ns ±24%   -21.60%  (p=0.000 n=20+20)
String1Remove9Add90Contains/sync.Map-16             637ns ± 5%     643ns ± 5%      ~     (p=0.344 n=20+20)
String1Range9Remove90Add900Contains/skipset-16     43.0ns ±14%    33.0ns ±20%   -23.19%  (p=0.000 n=19+20)
String1Range9Remove90Add900Contains/sync.Map-16    1.41µs ±12%    1.44µs ±15%      ~     (p=0.267 n=20+19)```