### PR TITLE
fix(lscq): add write barrier for LSCQ Pointer

### DIFF
--- a/collection/lscq/asm.go
+++ b/collection/lscq/asm.go
@@ -16,11 +16,13 @@
 
 package lscq
 
-import "unsafe"
+import (
+	"unsafe"
+)
 
 type uint128 [2]uint64
 
-func compareAndSwapUint128(addr *uint128, old, new uint128) (swapped bool)
+func compareAndSwapUint128(addr *uint128, old1, old2, new1, new2 uint64) (swapped bool)
 
 func loadUint128(addr *uint128) (val uint128)
 
@@ -28,10 +30,37 @@ func loadSCQNodePointer(addr unsafe.Pointer) (val scqNodePointer)
 
 func loadSCQNodeUint64(addr unsafe.Pointer) (val scqNodeUint64)
 
-func compareAndSwapSCQNodePointer(addr *scqNodePointer, old, new scqNodePointer) (swapped bool)
-
-func compareAndSwapSCQNodeUint64(addr *scqNodeUint64, old, new scqNodeUint64) (swapped bool)
-
 func atomicTestAndSetFirstBit(addr *uint64) (val uint64)
 
 func atomicTestAndSetSecondBit(addr *uint64) (val uint64)
+
+func resetNode(addr unsafe.Pointer)
+
+//go:nosplit
+func compareAndSwapSCQNodePointer(addr *scqNodePointer, old, new scqNodePointer) (swapped bool) {
+	// Ref: src/runtime/atomic_pointer.go:sync_atomic_CompareAndSwapPointer
+	if runtimeEnableWriteBarrier() {
+		runtimeatomicwb(&addr.data, new.data)
+	}
+	return compareAndSwapUint128((*uint128)(runtimenoescape(unsafe.Pointer(addr))), old.flags, uint64(uintptr(old.data)), new.flags, uint64(uintptr(new.data)))
+}
+
+func compareAndSwapSCQNodeUint64(addr *scqNodeUint64, old, new scqNodeUint64) (swapped bool) {
+	return compareAndSwapUint128((*uint128)(unsafe.Pointer(addr)), old.flags, old.data, new.flags, new.data)
+}
+
+func runtimeEnableWriteBarrier() bool
+
+//go:linkname runtimeatomicwb runtime.atomicwb
+func runtimeatomicwb(ptr *unsafe.Pointer, new unsafe.Pointer)
+
+//go:linkname runtimenoescape runtime.noescape
+func runtimenoescape(p unsafe.Pointer) unsafe.Pointer
+
+//go:nosplit
+func atomicWriteBarrier(ptr *unsafe.Pointer) {
+	// For SCQ dequeue only. (fastpath)
+	if runtimeEnableWriteBarrier() {
+		runtimeatomicwb(ptr, nil)
+	}
+}

--- a/collection/lscq/asm.go
+++ b/collection/lscq/asm.go
@@ -42,7 +42,7 @@ func compareAndSwapSCQNodePointer(addr *scqNodePointer, old, new scqNodePointer)
 	if runtimeEnableWriteBarrier() {
 		runtimeatomicwb(&addr.data, new.data)
 	}
-	return compareAndSwapUint128((*uint128)(runtimenoescape(unsafe.Pointer(addr))), old.flags, uint64(uintptr(old.data)), new.flags, uint64(uintptr(new.data)))
+	return compareAndSwapUint128((*uint128)(unsafe.Pointer(addr)), old.flags, uint64(uintptr(old.data)), new.flags, uint64(uintptr(new.data)))
 }
 
 func compareAndSwapSCQNodeUint64(addr *scqNodeUint64, old, new scqNodeUint64) (swapped bool) {
@@ -52,10 +52,8 @@ func compareAndSwapSCQNodeUint64(addr *scqNodeUint64, old, new scqNodeUint64) (s
 func runtimeEnableWriteBarrier() bool
 
 //go:linkname runtimeatomicwb runtime.atomicwb
+//go:noescape
 func runtimeatomicwb(ptr *unsafe.Pointer, new unsafe.Pointer)
-
-//go:linkname runtimenoescape runtime.noescape
-func runtimenoescape(p unsafe.Pointer) unsafe.Pointer
 
 //go:nosplit
 func atomicWriteBarrier(ptr *unsafe.Pointer) {

--- a/collection/lscq/asm.s
+++ b/collection/lscq/asm.s
@@ -45,12 +45,6 @@ TEXT ·loadSCQNodeUint64(SB),NOSPLIT,$0
 TEXT ·loadSCQNodePointer(SB),NOSPLIT,$0
 	JMP ·loadUint128(SB)
 
-TEXT ·compareAndSwapSCQNodePointer(SB),NOSPLIT,$0
-	JMP ·compareAndSwapUint128(SB)
-
-TEXT ·compareAndSwapSCQNodeUint64(SB),NOSPLIT,$0
-	JMP ·compareAndSwapUint128(SB)
-
 TEXT ·atomicTestAndSetFirstBit(SB),NOSPLIT,$0
 	MOVQ addr+0(FP), DX
 	LOCK
@@ -63,4 +57,16 @@ TEXT ·atomicTestAndSetSecondBit(SB),NOSPLIT,$0
 	LOCK
 	BTSQ $62,(DX)
 	MOVQ AX, val+8(FP)
+	RET
+
+TEXT ·resetNode(SB),NOSPLIT,$0
+	MOVQ addr+0(FP), DX
+	MOVQ $0, 8(DX)
+	LOCK
+	BTSQ $62, (DX)
+	RET
+
+TEXT ·runtimeEnableWriteBarrier(SB),NOSPLIT,$0
+	MOVL runtime·writeBarrier(SB), AX
+	MOVB AX, ret+0(FP)
 	RET

--- a/collection/lscq/asm.s
+++ b/collection/lscq/asm.s
@@ -18,10 +18,10 @@
 
 TEXT ·compareAndSwapUint128(SB),NOSPLIT,$0
 	MOVQ addr+0(FP), R8
-	MOVQ old_0+8(FP), AX
-	MOVQ old_1+16(FP), DX
-	MOVQ new_0+24(FP), BX
-	MOVQ new_1+32(FP), CX
+	MOVQ old1+8(FP), AX
+	MOVQ old2+16(FP), DX
+	MOVQ new1+24(FP), BX
+	MOVQ new2+32(FP), CX
 	LOCK
 	CMPXCHG16B (R8)
 	SETEQ swapped+40(FP)

--- a/collection/lscq/types_gen.go
+++ b/collection/lscq/types_gen.go
@@ -71,8 +71,8 @@ func main() {
 		data = strings.Replace(data, "scqNodePointer", "scqNode"+upper, -1)
 		data = strings.Replace(data, "compareAndSwapSCQNodePointer", "compareAndSwapSCQNode"+upper, -1)
 		data = strings.Replace(data, "loadSCQNodePointer", "loadSCQNode"+upper, -1)
-		// // Add the special case.
-		// data = data + strings.Replace(lengthFunction, "Int64Set", upper+"Set", 1)
+		data = strings.Replace(data, "pointerSCQPool", lower+"SCQPool", -1)
+		data = strings.Replace(data, "atomicWriteBarrier(&entAddr.data)", "", -1)
 		w.WriteString(data)
 		w.WriteString("\r\n")
 	}


### PR DESCRIPTION
The Go compiler will not insert write barrier for CAS2 automatically, this PR add write barrier for both CAS2 (Enqueue) and `resetNode` (dequeue). 