### PR TITLE
test(lang/syncx): add benchmark for RWMutex

### DIFF
--- a/lang/syncx/rwmutex_test.go
+++ b/lang/syncx/rwmutex_test.go
@@ -1,0 +1,160 @@
+// Copyright 2021 ByteDance Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package syncx
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/bytedance/gopkg/lang/fastrand"
+)
+
+func BenchmarkRWMutex100Read(b *testing.B) {
+	for nWorker := 1; nWorker <= 256; nWorker <<= 2 {
+		b.Run(fmt.Sprintf("syncx-%d", nWorker), func(b *testing.B) {
+			benchmarkSyncxRWMutexNWriteNRead(b, nWorker, 0)
+		})
+
+		b.Run(fmt.Sprintf("sync-%d", nWorker), func(b *testing.B) {
+			benchmarkSyncRWMutexNWriteNRead(b, nWorker, 0)
+		})
+	}
+}
+
+func BenchmarkRWMutex1Write99Read(b *testing.B) {
+	for nWorker := 1; nWorker <= 256; nWorker <<= 2 {
+		b.Run(fmt.Sprintf("syncx-%d", nWorker), func(b *testing.B) {
+			benchmarkSyncxRWMutexNWriteNRead(b, nWorker, 1)
+		})
+
+		b.Run(fmt.Sprintf("sync-%d", nWorker), func(b *testing.B) {
+			benchmarkSyncRWMutexNWriteNRead(b, nWorker, 1)
+		})
+	}
+}
+
+func BenchmarkRWMutex10Write90Read(b *testing.B) {
+	for nWorker := 1; nWorker <= 256; nWorker <<= 2 {
+		b.Run(fmt.Sprintf("syncx-%d", nWorker), func(b *testing.B) {
+			benchmarkSyncxRWMutexNWriteNRead(b, nWorker, 10)
+		})
+
+		b.Run(fmt.Sprintf("sync-%d", nWorker), func(b *testing.B) {
+			benchmarkSyncRWMutexNWriteNRead(b, nWorker, 10)
+		})
+	}
+}
+
+func BenchmarkRWMutex50Write50Read(b *testing.B) {
+	for nWorker := 1; nWorker <= 256; nWorker <<= 2 {
+		b.Run(fmt.Sprintf("syncx-%d", nWorker), func(b *testing.B) {
+			benchmarkSyncxRWMutexNWriteNRead(b, nWorker, 50)
+		})
+
+		b.Run(fmt.Sprintf("sync-%d", nWorker), func(b *testing.B) {
+			benchmarkSyncRWMutexNWriteNRead(b, nWorker, 50)
+		})
+	}
+}
+
+func benchmarkSyncRWMutexNWriteNRead(b *testing.B, nWorker, nWrite int) {
+	var res int // A mock resource we contention for
+
+	var mu sync.RWMutex
+	mu.Lock()
+
+	var wg sync.WaitGroup
+	wg.Add(nWorker)
+
+	n := b.N
+	quota := n / nWorker
+
+	for g := nWorker; g > 0; g-- {
+		// Comuse remaining quota
+		if g == 1 {
+			quota = n
+		}
+		go func(quota int) {
+			for i := 0; i < quota; i++ {
+				if fastrand.Intn(100) > nWrite-1 {
+					mu.RLock()
+					_ = res
+					mu.RUnlock()
+				} else {
+					mu.Lock()
+					res++
+					mu.Unlock()
+				}
+			}
+			wg.Done()
+		}(quota)
+
+		n -= quota
+	}
+
+	if n != 0 {
+		b.Fatalf("Incorrect quota assignments: %v remaining", n)
+	}
+
+	b.ResetTimer()
+	mu.Unlock()
+	wg.Wait()
+}
+
+func benchmarkSyncxRWMutexNWriteNRead(b *testing.B, nWorker, nWrite int) {
+	var res int // A mock resource we contention for
+
+	mu := NewRWMutex()
+	mu.Lock()
+
+	var wg sync.WaitGroup
+	wg.Add(nWorker)
+
+	n := b.N
+	quota := n / nWorker
+
+	for g := nWorker; g > 0; g-- {
+		// Comuse remaining quota
+		if g == 1 {
+			quota = n
+		}
+		go func(quota int) {
+			rmu := mu.RLocker()
+			for i := 0; i < quota; i++ {
+				if fastrand.Intn(100) > nWrite-1 {
+					rmu.Lock()
+					_ = res
+					rmu.Unlock()
+				} else {
+					mu.Lock()
+					res++
+					mu.Unlock()
+				}
+			}
+			wg.Done()
+		}(quota)
+
+		n -= quota
+	}
+
+	if n != 0 {
+		b.Fatalf("Incorrect quota assignments: %v remaining", n)
+	}
+
+	b.ResetTimer()
+	mu.Unlock()
+	wg.Wait()
+}


### PR DESCRIPTION
This PR adds benchmark for lang/syncx.RMMutex.

```bash
go test -v -cpuprofile cpu.pprof -cpu=1,4,8 -run=NOTEST -bench=BenchmarkRWMutex -benchtime=100000x -count=10 -timeout=60m > x.txt && benchstat x.txt
```

<details>
<summary>Result</summary>

```
name                              time/op
RWMutex100Read/syncx-1            17.7ns ± 8%
RWMutex100Read/syncx-1-4          16.3ns ± 0%
RWMutex100Read/syncx-1-8          16.3ns ± 0%
RWMutex100Read/sync-1             15.6ns ± 0%
RWMutex100Read/sync-1-4           15.6ns ± 1%
RWMutex100Read/sync-1-8           15.6ns ± 1%
RWMutex100Read/syncx-4            16.3ns ± 0%
RWMutex100Read/syncx-4-4          4.29ns ±10%
RWMutex100Read/syncx-4-8          4.26ns ± 1%
RWMutex100Read/sync-4             15.6ns ± 0%
RWMutex100Read/sync-4-4           31.1ns ± 2%
RWMutex100Read/sync-4-8           32.4ns ± 8%
RWMutex100Read/syncx-16           16.5ns ± 2%
RWMutex100Read/syncx-16-4         7.59ns ±91%
RWMutex100Read/syncx-16-8         6.48ns ±34%
RWMutex100Read/sync-16            15.6ns ± 0%
RWMutex100Read/sync-16-4          31.6ns ± 8%
RWMutex100Read/sync-16-8          31.1ns ± 7%
RWMutex100Read/syncx-64           16.6ns ± 1%
RWMutex100Read/syncx-64-4         12.6ns ±72%
RWMutex100Read/syncx-64-8         21.2ns ±20%
RWMutex100Read/sync-64            15.7ns ± 0%
RWMutex100Read/sync-64-4          30.4ns ±12%
RWMutex100Read/sync-64-8          31.0ns ± 7%
RWMutex100Read/syncx-256          17.1ns ± 2%
RWMutex100Read/syncx-256-4        19.0ns ±62%
RWMutex100Read/syncx-256-8        20.4ns ±23%
RWMutex100Read/sync-256           16.1ns ± 1%
RWMutex100Read/sync-256-4         29.9ns ±13%
RWMutex100Read/sync-256-8         32.3ns ±12%
RWMutex1Write99Read/syncx-1       18.8ns ± 1%
RWMutex1Write99Read/syncx-1-4     18.9ns ± 1%
RWMutex1Write99Read/syncx-1-8     18.8ns ± 0%
RWMutex1Write99Read/sync-1        15.7ns ± 1%
RWMutex1Write99Read/sync-1-4      15.9ns ± 3%
RWMutex1Write99Read/sync-1-8      15.8ns ± 1%
RWMutex1Write99Read/syncx-4       18.8ns ± 1%
RWMutex1Write99Read/syncx-4-4     29.9ns ±22%
RWMutex1Write99Read/syncx-4-8     33.0ns ±20%
RWMutex1Write99Read/sync-4        17.5ns ±11%
RWMutex1Write99Read/sync-4-4      35.1ns ± 3%
RWMutex1Write99Read/sync-4-8      35.6ns ± 3%
RWMutex1Write99Read/syncx-16      18.8ns ± 1%
RWMutex1Write99Read/syncx-16-4    39.6ns ±29%
RWMutex1Write99Read/syncx-16-8    39.3ns ±27%
RWMutex1Write99Read/sync-16       15.8ns ± 2%
RWMutex1Write99Read/sync-16-4     50.5ns ± 6%
RWMutex1Write99Read/sync-16-8     54.5ns ± 6%
RWMutex1Write99Read/syncx-64      19.0ns ± 1%
RWMutex1Write99Read/syncx-64-4    44.3ns ±12%
RWMutex1Write99Read/syncx-64-8    44.1ns ±15%
RWMutex1Write99Read/sync-64       15.8ns ± 1%
RWMutex1Write99Read/sync-64-4     62.3ns ± 6%
RWMutex1Write99Read/sync-64-8     65.2ns ± 7%
RWMutex1Write99Read/syncx-256     19.2ns ± 3%
RWMutex1Write99Read/syncx-256-4   40.1ns ±62%
RWMutex1Write99Read/syncx-256-8   36.7ns ±26%
RWMutex1Write99Read/sync-256      16.2ns ± 1%
RWMutex1Write99Read/sync-256-4    76.0ns ± 7%
RWMutex1Write99Read/sync-256-8    70.0ns ± 4%
RWMutex10Write90Read/syncx-1      41.3ns ± 1%
RWMutex10Write90Read/syncx-1-4    42.0ns ± 9%
RWMutex10Write90Read/syncx-1-8    40.8ns ± 2%
RWMutex10Write90Read/sync-1       16.3ns ± 2%
RWMutex10Write90Read/sync-1-4     16.6ns ± 1%
RWMutex10Write90Read/sync-1-8     16.6ns ± 1%
RWMutex10Write90Read/syncx-4      42.0ns ± 2%
RWMutex10Write90Read/syncx-4-4    77.3ns ±12%
RWMutex10Write90Read/syncx-4-8    76.1ns ±10%
RWMutex10Write90Read/sync-4       16.6ns ± 0%
RWMutex10Write90Read/sync-4-4     34.9ns ± 9%
RWMutex10Write90Read/sync-4-8     34.6ns ± 6%
RWMutex10Write90Read/syncx-16     41.8ns ± 8%
RWMutex10Write90Read/syncx-16-4   78.0ns ± 3%
RWMutex10Write90Read/syncx-16-8   78.9ns ± 7%
RWMutex10Write90Read/sync-16      16.7ns ±11%
RWMutex10Write90Read/sync-16-4    34.7ns ± 8%
RWMutex10Write90Read/sync-16-8    44.7ns ± 6%
RWMutex10Write90Read/syncx-64     53.9ns ±28%
RWMutex10Write90Read/syncx-64-4   94.8ns ±20%
RWMutex10Write90Read/syncx-64-8   79.4ns ± 6%
RWMutex10Write90Read/sync-64      16.9ns ± 3%
RWMutex10Write90Read/sync-64-4    34.1ns ± 3%
RWMutex10Write90Read/sync-64-8    37.6ns ±14%
RWMutex10Write90Read/syncx-256    43.5ns ± 4%
RWMutex10Write90Read/syncx-256-4  80.4ns ±13%
RWMutex10Write90Read/syncx-256-8  76.7ns ±12%
RWMutex10Write90Read/sync-256     17.1ns ± 4%
RWMutex10Write90Read/sync-256-4   22.2ns ± 7%
RWMutex10Write90Read/sync-256-8   21.9ns ± 9%
RWMutex50Write50Read/syncx-1       145ns ± 3%
RWMutex50Write50Read/syncx-1-4     144ns ± 2%
RWMutex50Write50Read/syncx-1-8     167ns ±15%
RWMutex50Write50Read/sync-1       20.6ns ± 1%
RWMutex50Write50Read/sync-1-4     20.6ns ± 1%
RWMutex50Write50Read/sync-1-8     20.6ns ± 0%
RWMutex50Write50Read/syncx-4       159ns ±18%
RWMutex50Write50Read/syncx-4-4     182ns ± 2%
RWMutex50Write50Read/syncx-4-8     187ns ± 3%
RWMutex50Write50Read/sync-4       21.4ns ±10%
RWMutex50Write50Read/sync-4-4     38.5ns ± 5%
RWMutex50Write50Read/sync-4-8     38.8ns ± 5%
RWMutex50Write50Read/syncx-16      144ns ± 3%
RWMutex50Write50Read/syncx-16-4    183ns ± 1%
RWMutex50Write50Read/syncx-16-8    186ns ± 1%
RWMutex50Write50Read/sync-16      20.9ns ±10%
RWMutex50Write50Read/sync-16-4    40.5ns ± 4%
RWMutex50Write50Read/sync-16-8    40.9ns ± 2%
RWMutex50Write50Read/syncx-64      144ns ± 2%
RWMutex50Write50Read/syncx-64-4    184ns ± 2%
RWMutex50Write50Read/syncx-64-8    186ns ± 2%
RWMutex50Write50Read/sync-64      20.7ns ± 6%
RWMutex50Write50Read/sync-64-4    40.2ns ± 3%
RWMutex50Write50Read/sync-64-8    40.3ns ± 3%
RWMutex50Write50Read/syncx-256     134ns ± 3%
RWMutex50Write50Read/syncx-256-4   211ns ± 6%
RWMutex50Write50Read/syncx-256-8   201ns ± 4%
RWMutex50Write50Read/sync-256     22.1ns ±28%
RWMutex50Write50Read/sync-256-4   36.3ns ± 4%
RWMutex50Write50Read/sync-256-8   36.0ns ± 3%
```
</details>

# Highlights

> Hint: For benchmark "RWMutex100Read/syncx-256-8",
> - "syncx" means that we are benching syncx.RMutex
> - 256 is number of contestants (goroutine)
> - 8 is number of CPU (P)
 
- syncx.RWMutex has all-round advantages over sync.RWMutex in read-only and 1write99read asituation:
- The more CPUs, the more obvious the advantage of  syncx.RWMutex

```
RWMutex100Read/syncx-1            17.7ns ± 8%
RWMutex100Read/syncx-1-4          16.3ns ± 0%
RWMutex100Read/syncx-1-8          16.3ns ± 0%
RWMutex100Read/sync-1             15.6ns ± 0%
RWMutex100Read/sync-1-4           15.6ns ± 1%
RWMutex100Read/sync-1-8           15.6ns ± 1%

RWMutex100Read/syncx-256          17.1ns ± 2%
RWMutex100Read/syncx-256-4        19.0ns ±62%
RWMutex100Read/syncx-256-8        20.4ns ±23%
RWMutex100Read/sync-256           16.1ns ± 1%
RWMutex100Read/sync-256-4         29.9ns ±13%
RWMutex100Read/sync-256-8         32.3ns ±12%

RWMutex1Write99Read/syncx-256     19.2ns ± 3%
RWMutex1Write99Read/syncx-256-4   40.1ns ±62%
RWMutex1Write99Read/syncx-256-8   36.7ns ±26%
RWMutex1Write99Read/sync-256      16.2ns ± 1%
RWMutex1Write99Read/sync-256-4    76.0ns ± 7%
RWMutex1Write99Read/sync-256-8    70.0ns ± 4%
```

- syncx.RWMutex has no advantage over sync.RWMutex when there are more write operations than read.

```
RWMutex10Write90Read/syncx-256    43.5ns ± 4%
RWMutex10Write90Read/syncx-256-4  80.4ns ±13%
RWMutex10Write90Read/syncx-256-8  76.7ns ±12%
RWMutex10Write90Read/sync-256     17.1ns ± 4%
RWMutex10Write90Read/sync-256-4   22.2ns ± 7%
RWMutex10Write90Read/sync-256-8   21.9ns ± 9%

RWMutex50Write50Read/syncx-256     134ns ± 3%
RWMutex50Write50Read/syncx-256-4   211ns ± 6%
RWMutex50Write50Read/syncx-256-8   201ns ± 4%
RWMutex50Write50Read/sync-256     22.1ns ±28%
RWMutex50Write50Read/sync-256-4   36.3ns ± 4%
RWMutex50Write50Read/sync-256-8   36.0ns ± 3%
```