### PR TITLE
feat(lang/fastrand): add Read([]byte) function

### DIFF
--- a/lang/fastrand/fastrand_test.go
+++ b/lang/fastrand/fastrand_test.go
@@ -21,6 +21,9 @@ import (
 
 func TestAll(t *testing.T) {
 	_ = Uint32()
+
+	bytes := make([]byte, 1000)
+	_, _ = Read(bytes)
 }
 
 func BenchmarkSingleCore(b *testing.B) {


### PR DESCRIPTION
# What

This PR add a new function `func Read([]byte) (n int, err error)` for fastrand package. It has the same signature with `math/rand.Read` and `math/rand.(*Rand).Read`.

# Why

`fastrand` is so good that I want to use it everywhere~
And in my benchmark, it's  at least 30% faster than `math/rand.(*Rand).Read` in single goroutine.

# How

Just like `math/rand.Read`.