### PR TITLE
refactor: move from deprecated ioutil to os and io packages

### DIFF
--- a/collection/hashset/types_gen.go
+++ b/collection/hashset/types_gen.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build ignore
 // +build ignore
 
 package main
@@ -19,7 +20,7 @@ package main
 import (
 	"bytes"
 	"go/format"
-	"io/ioutil"
+	"io"
 	"os"
 	"strings"
 )
@@ -33,7 +34,7 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
-	filedata, err := ioutil.ReadAll(f)
+	filedata, err := io.ReadAll(f)
 	if err != nil {
 		panic(err)
 	}
@@ -80,7 +81,7 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
-	if err := ioutil.WriteFile("types.go", out, 0660); err != nil {
+	if err := os.WriteFile("types.go", out, 0660); err != nil {
 		panic(err)
 	}
 }

--- a/collection/lscq/types_gen.go
+++ b/collection/lscq/types_gen.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build ignore
 // +build ignore
 
 package main
@@ -19,7 +20,7 @@ package main
 import (
 	"bytes"
 	"go/format"
-	"io/ioutil"
+	"io"
 	"os"
 	"strings"
 )
@@ -44,7 +45,7 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
-	filedata, err := ioutil.ReadAll(f)
+	filedata, err := io.ReadAll(f)
 	if err != nil {
 		panic(err)
 	}
@@ -81,7 +82,7 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
-	if err := ioutil.WriteFile("types.go", out, 0660); err != nil {
+	if err := os.WriteFile("types.go", out, 0660); err != nil {
 		panic(err)
 	}
 }

--- a/collection/skipmap/types_gen.go
+++ b/collection/skipmap/types_gen.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build ignore
 // +build ignore
 
 package main
@@ -19,7 +20,7 @@ package main
 import (
 	"bytes"
 	"go/format"
-	"io/ioutil"
+	"io"
 	"os"
 	"strings"
 )
@@ -29,7 +30,7 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
-	filedata, err := ioutil.ReadAll(f)
+	filedata, err := io.ReadAll(f)
 	if err != nil {
 		panic(err)
 	}
@@ -80,7 +81,7 @@ func main() {
 		panic(err)
 	}
 
-	if err := ioutil.WriteFile("types.go", out, 0660); err != nil {
+	if err := os.WriteFile("types.go", out, 0660); err != nil {
 		panic(err)
 	}
 }

--- a/collection/skipset/types_gen.go
+++ b/collection/skipset/types_gen.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build ignore
 // +build ignore
 
 package main
@@ -19,7 +20,7 @@ package main
 import (
 	"bytes"
 	"go/format"
-	"io/ioutil"
+	"io"
 	"os"
 	"strings"
 )
@@ -29,7 +30,7 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
-	filedata, err := ioutil.ReadAll(f)
+	filedata, err := io.ReadAll(f)
 	if err != nil {
 		panic(err)
 	}
@@ -80,7 +81,7 @@ func main() {
 		panic(err)
 	}
 
-	if err := ioutil.WriteFile("types.go", out, 0660); err != nil {
+	if err := os.WriteFile("types.go", out, 0660); err != nil {
 		panic(err)
 	}
 }


### PR DESCRIPTION
Since gopkg and CI are currently using Go 1.16, so it is safe to remove deprecated `ioutil` package, ref https://golang.org/doc/go1.16#ioutil.