### PR TITLE
chore: add github issue forms

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,71 @@
+name: Bug Report
+description: File a bug report
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report!
+
+  - type: input
+    attributes:
+      label: Operating System
+      description: What operating system are you using?
+      placeholder: "Example: Debian GNU/Linux 9 (stretch)"
+    validations:
+      required: true
+  - type: input
+    attributes:
+      label: Go Version
+      description: What version of golang are you using?
+      placeholder: "Example: go1.16.5 linux/amd64"
+    validations:
+      required: true
+  - type: input
+    attributes:
+      label: Package Version
+      description: What version of bytedance/gopkg are you using?
+      placeholder: "Example: 20210913/main/develop"
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Affected Packages 
+      description: Which packages are affected by this issue?
+      placeholder: |
+        One package per line, for example:
+
+        - lang/fastrand
+        - collection/skipset
+        - ...
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Expected Behavior
+      description: What did you expect to happen?
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Actual Behavior
+      description: What actually happened?
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Reproduction Steps
+      description: How do you trigger this bug? Please walk us through it step by step.
+      placeholder: |
+        1.
+        2.
+        3.
+        ...
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Other Information
+      description: Do you still need to add any information?

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,7 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Security Bug Report
+    url: https://github.com/bytedance/gopkg/blob/develop/CONTRIBUTING.md#3-security-bugs
+    about: |
+      Please do not report the safe disclosure of bugs to public issues.
+      Contact us by email (gopkg@bytedance.com)

--- a/.github/ISSUE_TEMPLATE/feature_reqeust.yml
+++ b/.github/ISSUE_TEMPLATE/feature_reqeust.yml
@@ -1,0 +1,38 @@
+# Reference: https://github.com/jekyll/jekyll/blob/master/.github/ISSUE_TEMPLATE/feature_request.md
+
+name: Feature Request
+description: File a feature request
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this feature request!
+
+  - type: textarea
+    attributes:
+      label: Summary
+      description: Please give a one-paragraph explanation of the feature.
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Motivation
+      description: Why do you want to see this feature? 
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Explanation
+      description: |
+        Please explain the proposal as if it was already included in the project and you
+        were teaching it to another programmer. That generally means:
+
+        - Introducing new named concepts.
+        - Explaining the feature largely in terms of examples.
+        - If applicable, provide sample error messages, deprecation warnings, or
+        migration guidance.
+        
+        *If this is a small feature, you may omit this section.*

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -1,0 +1,10 @@
+name: Question
+description: Ask a question
+labels: ["question"]
+body:
+  - type: textarea
+    attributes:
+      label: Question
+      description: What do you want to know?
+    validations:
+      required: true


### PR DESCRIPTION
# Summary

[Github issue form](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms) is a friendly mechanism for helping people opening an issue.

Use can file an issue by filling a predefined issue form, rather than orgranize the content by themself.
(We also retention the capacity of opening a blank issue for user.)

In this PR we add three forms:

- Bug report 
- Feature reqeust
- Question

# Preview

The froms choosing page:

<details>

![图片](https://user-images.githubusercontent.com/8090459/139046529-a23cfbc1-e2e7-44bc-a502-d236b5d96932.png)

</details>
 
The issue form:

<details>

![图片](https://user-images.githubusercontent.com/8090459/139046003-b64fa3e7-8a8f-43af-905c-ff3d05a7d9d0.png)

</details>

The created issue:

<details>

![图片](https://user-images.githubusercontent.com/8090459/139046194-c280be11-b82b-4a2e-b6d5-f06a985e6e8c.png)

</details>
