### PR TITLE
Fix small typo (string value)

### DIFF
--- a/cloud/metainfo/info.go
+++ b/cloud/metainfo/info.go
@@ -21,8 +21,8 @@ import (
 // The prefix listed below may be used to tag the types of values when there is no context to carry them.
 const (
 	PrefixPersistent         = "RPC_PERSIST_"
-	PrefixTransient          = "RPC_TRANSIT_"
-	PrefixTransientUpstream  = "RPC_TRANSIT_UPSTREAM_"
+	PrefixTransient          = "RPC_TRANSIENT_"
+	PrefixTransientUpstream  = "RPC_TRANSIENT_UPSTREAM_"
 	PrefixBackward           = "RPC_BACKWARD_"
 	PrefixBackwardDownstream = "RPC_BACKWARD_DOWNSTREAM_"
 


### PR DESCRIPTION
- passed the tests in cloud/metainfo package.
- no direct reference of the string (RPC_TRANSIT.../RPC_TRANSIENT...) anywhere in the package. Only the corresponding variable names are referenced, and they remain unchanged (PrefixTransient and PrefixTransientUpstream) .