### PR TITLE
fix(xxhash3): fix data race

### DIFF
--- a/util/xxhash3/hash.go
+++ b/util/xxhash3/hash.go
@@ -117,7 +117,7 @@ func xxh3HashLarge(xinput unsafe.Pointer, l int) (acc uint64) {
 		return xxh3Avalanche(acc)
 	}
 
-	xacc = [8]uint64{
+	var xacc = [8]uint64{
 		prime32_3, prime64_1, prime64_2, prime64_3,
 		prime64_4, prime32_2, prime64_5, prime32_1}
 

--- a/util/xxhash3/hash128.go
+++ b/util/xxhash3/hash128.go
@@ -195,7 +195,7 @@ func xxh3HashLarge128(xinput unsafe.Pointer, l int) (acc [2]uint64) {
 		return [2]uint64{accHigh64, accLow64}
 	}
 
-	xacc = [8]uint64{
+	var xacc = [8]uint64{
 		prime32_3, prime64_1, prime64_2, prime64_3,
 		prime64_4, prime32_2, prime64_5, prime32_1}
 

--- a/util/xxhash3/util.go
+++ b/util/xxhash3/util.go
@@ -25,7 +25,6 @@ import (
 var (
 	avx2        = cpu.X86.HasAVX2
 	sse2        = cpu.X86.HasSSE2
-	xacc        = [8]uint64{}
 	hashfunc    = [2]func(unsafe.Pointer, int) uint64{xxh3HashSmall, xxh3HashLarge}
 	hashfunc128 = [2]func(unsafe.Pointer, int) [2]uint64{xxh3HashSmall128, xxh3HashLarge128}
 )


### PR DESCRIPTION
xxhash单测出现开启-race出现报错，case
```
func TestConcurrent(t *testing.T) {
	var dataList = [][]byte{
		make([]byte, 1000),
		make([]byte, 1000),
		make([]byte, 1000),
	}
	var wg = sync.WaitGroup{}
	for _, data := range dataList {
		wg.Add(1)
		data := data
		go func() {
			// xxh3HashLarge
			Hash(data)
			wg.Done()
		}()
	}
	wg.Wait()
}
```
报错信息
```
=== RUN   TestConcurrent
==================
WARNING: DATA RACE
Write at 0x000001389480 by goroutine 21:
  github.com/bytedance/gopkg/util/xxhash3.xxh3HashLarge()
      /Users/huanghongkai/go/src/bytedance/gopkg/util/xxhash3/hash.go:120 +0x2ef9
  github.com/bytedance/gopkg/util/xxhash3.Hash()
      /Users/huanghongkai/go/src/bytedance/gopkg/util/xxhash3/hash.go:33 +0xc9
  github.com/bytedance/gopkg/util/xxhash3.TestConcurrent.func1()
      /Users/huanghongkai/go/src/bytedance/gopkg/util/xxhash3/util_test.go:21 +0x4c

Previous write at 0x000001389480 by goroutine 20:
  github.com/bytedance/gopkg/util/xxhash3.xxh3HashLarge()
      /Users/huanghongkai/go/src/bytedance/gopkg/util/xxhash3/hash.go:120 +0x2ef9
  github.com/bytedance/gopkg/util/xxhash3.Hash()
      /Users/huanghongkai/go/src/bytedance/gopkg/util/xxhash3/hash.go:33 +0xc9
  github.com/bytedance/gopkg/util/xxhash3.TestConcurrent.func1()
      /Users/huanghongkai/go/src/bytedance/gopkg/util/xxhash3/util_test.go:21 +0x4c

Goroutine 21 (running) created at:
  github.com/bytedance/gopkg/util/xxhash3.TestConcurrent()
      /Users/huanghongkai/go/src/bytedance/gopkg/util/xxhash3/util_test.go:19 +0x23a
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1193 +0x202

Goroutine 20 (finished) created at:
  github.com/bytedance/gopkg/util/xxhash3.TestConcurrent()
      /Users/huanghongkai/go/src/bytedance/gopkg/util/xxhash3/util_test.go:19 +0x23a
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1193 +0x202
==================
    testing.go:1092: race detected during execution of test
--- FAIL: TestConcurrent (0.00s)
=== CONT  
    testing.go:1092: race detected during execution of test
FAIL
exit status 1
FAIL    github.com/bytedance/gopkg/util/xxhash3 12.903s
```