### PR TITLE
feat(skipmap): generate the level lazily in LoadOrStore

### DIFF
--- a/collection/skipmap/bench_test.go
+++ b/collection/skipmap/bench_test.go
@@ -1,0 +1,83 @@
+package skipmap
+
+import (
+	"testing"
+
+	"github.com/bytedance/gopkg/lang/fastrand"
+)
+
+func BenchmarkLoadOrStoreExist(b *testing.B) {
+	m := NewInt()
+	m.Store(1, 1)
+	b.ResetTimer()
+	b.RunParallel(func(p *testing.PB) {
+		for p.Next() {
+			m.LoadOrStore(1, 1)
+		}
+	})
+}
+
+func BenchmarkLoadOrStoreLazyExist(b *testing.B) {
+	m := NewInt()
+	m.Store(1, 1)
+	b.ResetTimer()
+	b.RunParallel(func(p *testing.PB) {
+		for p.Next() {
+			m.LoadOrStoreLazy(1, func() interface{} { return 1 })
+		}
+	})
+}
+
+func BenchmarkLoadOrStoreExistSingle(b *testing.B) {
+	m := NewInt()
+	m.Store(1, 1)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		m.LoadOrStore(1, 1)
+	}
+}
+
+func BenchmarkLoadOrStoreLazyExistSingle(b *testing.B) {
+	m := NewInt()
+	m.Store(1, 1)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		m.LoadOrStoreLazy(1, func() interface{} { return 1 })
+	}
+}
+
+func BenchmarkLoadOrStoreRandom(b *testing.B) {
+	m := NewInt()
+	b.ResetTimer()
+	b.RunParallel(func(p *testing.PB) {
+		for p.Next() {
+			m.LoadOrStore(fastrand.Int(), 1)
+		}
+	})
+}
+
+func BenchmarkLoadOrStoreLazyRandom(b *testing.B) {
+	m := NewInt()
+	b.ResetTimer()
+	b.RunParallel(func(p *testing.PB) {
+		for p.Next() {
+			m.LoadOrStoreLazy(fastrand.Int(), func() interface{} { return 1 })
+		}
+	})
+}
+
+func BenchmarkLoadOrStoreRandomSingle(b *testing.B) {
+	m := NewInt()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		m.LoadOrStore(fastrand.Int(), 1)
+	}
+}
+
+func BenchmarkLoadOrStoreLazyRandomSingle(b *testing.B) {
+	m := NewInt()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		m.LoadOrStoreLazy(fastrand.Int(), func() interface{} { return 1 })
+	}
+}

--- a/collection/skipmap/skipmap.go
+++ b/collection/skipmap/skipmap.go
@@ -15,6 +15,8 @@
 // Package skipmap is a high-performance, scalable, concurrent-safe map based on skip-list.
 // In the typical pattern(100000 operations, 90%LOAD 9%STORE 1%DELETE, 8C16T), the skipmap
 // up to 10x faster than the built-in sync.Map.
+//
+//go:generate go run types_gen.go
 package skipmap
 
 import (
@@ -311,8 +313,11 @@ func (s *Int64Map) LoadAndDelete(key int64) (value interface{}, loaded bool) {
 // The loaded result is true if the value was loaded, false if stored.
 // (Modified from Store)
 func (s *Int64Map) LoadOrStore(key int64, value interface{}) (actual interface{}, loaded bool) {
-	level := s.randomlevel()
-	var preds, succs [maxLevel]*int64Node
+	var (
+		level        int
+		preds, succs [maxLevel]*int64Node
+		hl           = int(atomic.LoadInt64(&s.highestLevel))
+	)
 	for {
 		nodeFound := s.findNode(key, &preds, &succs)
 		if nodeFound != nil { // indicating the key is already in the skip-list
@@ -332,6 +337,16 @@ func (s *Int64Map) LoadOrStore(key int64, value interface{}) (actual interface{}
 			valid                = true
 			pred, succ, prevPred *int64Node
 		)
+		if level == 0 {
+			level = s.randomlevel()
+			if level > hl {
+				// If the highest level is updated, usually means that many goroutines
+				// are inserting items. Hopefully we can find a better path in next loop.
+				// TODO(zyh): consider filling the preds if s.header[level].next == nil,
+				// but this strategy's performance is almost the same as the existing method.
+				continue
+			}
+		}
 		for layer := 0; valid && layer < level; layer++ {
 			pred = preds[layer]   // target node's previous node
 			succ = succs[layer]   // target node's next node
@@ -368,8 +383,11 @@ func (s *Int64Map) LoadOrStore(key int64, value interface{}) (actual interface{}
 // The loaded result is true if the value was loaded, false if stored.
 // (Modified from LoadOrStore)
 func (s *Int64Map) LoadOrStoreLazy(key int64, f func() interface{}) (actual interface{}, loaded bool) {
-	level := s.randomlevel()
-	var preds, succs [maxLevel]*int64Node
+	var (
+		level        int
+		preds, succs [maxLevel]*int64Node
+		hl           = int(atomic.LoadInt64(&s.highestLevel))
+	)
 	for {
 		nodeFound := s.findNode(key, &preds, &succs)
 		if nodeFound != nil { // indicating the key is already in the skip-list
@@ -389,6 +407,16 @@ func (s *Int64Map) LoadOrStoreLazy(key int64, f func() interface{}) (actual inte
 			valid                = true
 			pred, succ, prevPred *int64Node
 		)
+		if level == 0 {
+			level = s.randomlevel()
+			if level > hl {
+				// If the highest level is updated, usually means that many goroutines
+				// are inserting items. Hopefully we can find a better path in next loop.
+				// TODO(zyh): consider filling the preds if s.header[level].next == nil,
+				// but this strategy's performance is almost the same as the existing method.
+				continue
+			}
+		}
 		for layer := 0; valid && layer < level; layer++ {
 			pred = preds[layer]   // target node's previous node
 			succ = succs[layer]   // target node's next node

--- a/collection/skipmap/types.go
+++ b/collection/skipmap/types.go
@@ -309,8 +309,11 @@ func (s *Float32Map) LoadAndDelete(key float32) (value interface{}, loaded bool)
 // The loaded result is true if the value was loaded, false if stored.
 // (Modified from Store)
 func (s *Float32Map) LoadOrStore(key float32, value interface{}) (actual interface{}, loaded bool) {
-	level := s.randomlevel()
-	var preds, succs [maxLevel]*float32Node
+	var (
+		level        int
+		preds, succs [maxLevel]*float32Node
+		hl           = int(atomic.LoadInt64(&s.highestLevel))
+	)
 	for {
 		nodeFound := s.findNode(key, &preds, &succs)
 		if nodeFound != nil { // indicating the key is already in the skip-list
@@ -330,6 +333,16 @@ func (s *Float32Map) LoadOrStore(key float32, value interface{}) (actual interfa
 			valid                = true
 			pred, succ, prevPred *float32Node
 		)
+		if level == 0 {
+			level = s.randomlevel()
+			if level > hl {
+				// If the highest level is updated, usually means that many goroutines
+				// are inserting items. Hopefully we can find a better path in next loop.
+				// TODO(zyh): consider filling the preds if s.header[level].next == nil,
+				// but this strategy's performance is almost the same as the existing method.
+				continue
+			}
+		}
 		for layer := 0; valid && layer < level; layer++ {
 			pred = preds[layer]   // target node's previous node
 			succ = succs[layer]   // target node's next node
@@ -366,8 +379,11 @@ func (s *Float32Map) LoadOrStore(key float32, value interface{}) (actual interfa
 // The loaded result is true if the value was loaded, false if stored.
 // (Modified from LoadOrStore)
 func (s *Float32Map) LoadOrStoreLazy(key float32, f func() interface{}) (actual interface{}, loaded bool) {
-	level := s.randomlevel()
-	var preds, succs [maxLevel]*float32Node
+	var (
+		level        int
+		preds, succs [maxLevel]*float32Node
+		hl           = int(atomic.LoadInt64(&s.highestLevel))
+	)
 	for {
 		nodeFound := s.findNode(key, &preds, &succs)
 		if nodeFound != nil { // indicating the key is already in the skip-list
@@ -387,6 +403,16 @@ func (s *Float32Map) LoadOrStoreLazy(key float32, f func() interface{}) (actual 
 			valid                = true
 			pred, succ, prevPred *float32Node
 		)
+		if level == 0 {
+			level = s.randomlevel()
+			if level > hl {
+				// If the highest level is updated, usually means that many goroutines
+				// are inserting items. Hopefully we can find a better path in next loop.
+				// TODO(zyh): consider filling the preds if s.header[level].next == nil,
+				// but this strategy's performance is almost the same as the existing method.
+				continue
+			}
+		}
 		for layer := 0; valid && layer < level; layer++ {
 			pred = preds[layer]   // target node's previous node
 			succ = succs[layer]   // target node's next node
@@ -795,8 +821,11 @@ func (s *Float32MapDesc) LoadAndDelete(key float32) (value interface{}, loaded b
 // The loaded result is true if the value was loaded, false if stored.
 // (Modified from Store)
 func (s *Float32MapDesc) LoadOrStore(key float32, value interface{}) (actual interface{}, loaded bool) {
-	level := s.randomlevel()
-	var preds, succs [maxLevel]*float32NodeDesc
+	var (
+		level        int
+		preds, succs [maxLevel]*float32NodeDesc
+		hl           = int(atomic.LoadInt64(&s.highestLevel))
+	)
 	for {
 		nodeFound := s.findNode(key, &preds, &succs)
 		if nodeFound != nil { // indicating the key is already in the skip-list
@@ -816,6 +845,16 @@ func (s *Float32MapDesc) LoadOrStore(key float32, value interface{}) (actual int
 			valid                = true
 			pred, succ, prevPred *float32NodeDesc
 		)
+		if level == 0 {
+			level = s.randomlevel()
+			if level > hl {
+				// If the highest level is updated, usually means that many goroutines
+				// are inserting items. Hopefully we can find a better path in next loop.
+				// TODO(zyh): consider filling the preds if s.header[level].next == nil,
+				// but this strategy's performance is almost the same as the existing method.
+				continue
+			}
+		}
 		for layer := 0; valid && layer < level; layer++ {
 			pred = preds[layer]   // target node's previous node
 			succ = succs[layer]   // target node's next node
@@ -852,8 +891,11 @@ func (s *Float32MapDesc) LoadOrStore(key float32, value interface{}) (actual int
 // The loaded result is true if the value was loaded, false if stored.
 // (Modified from LoadOrStore)
 func (s *Float32MapDesc) LoadOrStoreLazy(key float32, f func() interface{}) (actual interface{}, loaded bool) {
-	level := s.randomlevel()
-	var preds, succs [maxLevel]*float32NodeDesc
+	var (
+		level        int
+		preds, succs [maxLevel]*float32NodeDesc
+		hl           = int(atomic.LoadInt64(&s.highestLevel))
+	)
 	for {
 		nodeFound := s.findNode(key, &preds, &succs)
 		if nodeFound != nil { // indicating the key is already in the skip-list
@@ -873,6 +915,16 @@ func (s *Float32MapDesc) LoadOrStoreLazy(key float32, f func() interface{}) (act
 			valid                = true
 			pred, succ, prevPred *float32NodeDesc
 		)
+		if level == 0 {
+			level = s.randomlevel()
+			if level > hl {
+				// If the highest level is updated, usually means that many goroutines
+				// are inserting items. Hopefully we can find a better path in next loop.
+				// TODO(zyh): consider filling the preds if s.header[level].next == nil,
+				// but this strategy's performance is almost the same as the existing method.
+				continue
+			}
+		}
 		for layer := 0; valid && layer < level; layer++ {
 			pred = preds[layer]   // target node's previous node
 			succ = succs[layer]   // target node's next node
@@ -1281,8 +1333,11 @@ func (s *Float64Map) LoadAndDelete(key float64) (value interface{}, loaded bool)
 // The loaded result is true if the value was loaded, false if stored.
 // (Modified from Store)
 func (s *Float64Map) LoadOrStore(key float64, value interface{}) (actual interface{}, loaded bool) {
-	level := s.randomlevel()
-	var preds, succs [maxLevel]*float64Node
+	var (
+		level        int
+		preds, succs [maxLevel]*float64Node
+		hl           = int(atomic.LoadInt64(&s.highestLevel))
+	)
 	for {
 		nodeFound := s.findNode(key, &preds, &succs)
 		if nodeFound != nil { // indicating the key is already in the skip-list
@@ -1302,6 +1357,16 @@ func (s *Float64Map) LoadOrStore(key float64, value interface{}) (actual interfa
 			valid                = true
 			pred, succ, prevPred *float64Node
 		)
+		if level == 0 {
+			level = s.randomlevel()
+			if level > hl {
+				// If the highest level is updated, usually means that many goroutines
+				// are inserting items. Hopefully we can find a better path in next loop.
+				// TODO(zyh): consider filling the preds if s.header[level].next == nil,
+				// but this strategy's performance is almost the same as the existing method.
+				continue
+			}
+		}
 		for layer := 0; valid && layer < level; layer++ {
 			pred = preds[layer]   // target node's previous node
 			succ = succs[layer]   // target node's next node
@@ -1338,8 +1403,11 @@ func (s *Float64Map) LoadOrStore(key float64, value interface{}) (actual interfa
 // The loaded result is true if the value was loaded, false if stored.
 // (Modified from LoadOrStore)
 func (s *Float64Map) LoadOrStoreLazy(key float64, f func() interface{}) (actual interface{}, loaded bool) {
-	level := s.randomlevel()
-	var preds, succs [maxLevel]*float64Node
+	var (
+		level        int
+		preds, succs [maxLevel]*float64Node
+		hl           = int(atomic.LoadInt64(&s.highestLevel))
+	)
 	for {
 		nodeFound := s.findNode(key, &preds, &succs)
 		if nodeFound != nil { // indicating the key is already in the skip-list
@@ -1359,6 +1427,16 @@ func (s *Float64Map) LoadOrStoreLazy(key float64, f func() interface{}) (actual 
 			valid                = true
 			pred, succ, prevPred *float64Node
 		)
+		if level == 0 {
+			level = s.randomlevel()
+			if level > hl {
+				// If the highest level is updated, usually means that many goroutines
+				// are inserting items. Hopefully we can find a better path in next loop.
+				// TODO(zyh): consider filling the preds if s.header[level].next == nil,
+				// but this strategy's performance is almost the same as the existing method.
+				continue
+			}
+		}
 		for layer := 0; valid && layer < level; layer++ {
 			pred = preds[layer]   // target node's previous node
 			succ = succs[layer]   // target node's next node
@@ -1767,8 +1845,11 @@ func (s *Float64MapDesc) LoadAndDelete(key float64) (value interface{}, loaded b
 // The loaded result is true if the value was loaded, false if stored.
 // (Modified from Store)
 func (s *Float64MapDesc) LoadOrStore(key float64, value interface{}) (actual interface{}, loaded bool) {
-	level := s.randomlevel()
-	var preds, succs [maxLevel]*float64NodeDesc
+	var (
+		level        int
+		preds, succs [maxLevel]*float64NodeDesc
+		hl           = int(atomic.LoadInt64(&s.highestLevel))
+	)
 	for {
 		nodeFound := s.findNode(key, &preds, &succs)
 		if nodeFound != nil { // indicating the key is already in the skip-list
@@ -1788,6 +1869,16 @@ func (s *Float64MapDesc) LoadOrStore(key float64, value interface{}) (actual int
 			valid                = true
 			pred, succ, prevPred *float64NodeDesc
 		)
+		if level == 0 {
+			level = s.randomlevel()
+			if level > hl {
+				// If the highest level is updated, usually means that many goroutines
+				// are inserting items. Hopefully we can find a better path in next loop.
+				// TODO(zyh): consider filling the preds if s.header[level].next == nil,
+				// but this strategy's performance is almost the same as the existing method.
+				continue
+			}
+		}
 		for layer := 0; valid && layer < level; layer++ {
 			pred = preds[layer]   // target node's previous node
 			succ = succs[layer]   // target node's next node
@@ -1824,8 +1915,11 @@ func (s *Float64MapDesc) LoadOrStore(key float64, value interface{}) (actual int
 // The loaded result is true if the value was loaded, false if stored.
 // (Modified from LoadOrStore)
 func (s *Float64MapDesc) LoadOrStoreLazy(key float64, f func() interface{}) (actual interface{}, loaded bool) {
-	level := s.randomlevel()
-	var preds, succs [maxLevel]*float64NodeDesc
+	var (
+		level        int
+		preds, succs [maxLevel]*float64NodeDesc
+		hl           = int(atomic.LoadInt64(&s.highestLevel))
+	)
 	for {
 		nodeFound := s.findNode(key, &preds, &succs)
 		if nodeFound != nil { // indicating the key is already in the skip-list
@@ -1845,6 +1939,16 @@ func (s *Float64MapDesc) LoadOrStoreLazy(key float64, f func() interface{}) (act
 			valid                = true
 			pred, succ, prevPred *float64NodeDesc
 		)
+		if level == 0 {
+			level = s.randomlevel()
+			if level > hl {
+				// If the highest level is updated, usually means that many goroutines
+				// are inserting items. Hopefully we can find a better path in next loop.
+				// TODO(zyh): consider filling the preds if s.header[level].next == nil,
+				// but this strategy's performance is almost the same as the existing method.
+				continue
+			}
+		}
 		for layer := 0; valid && layer < level; layer++ {
 			pred = preds[layer]   // target node's previous node
 			succ = succs[layer]   // target node's next node
@@ -2253,8 +2357,11 @@ func (s *Int32Map) LoadAndDelete(key int32) (value interface{}, loaded bool) {
 // The loaded result is true if the value was loaded, false if stored.
 // (Modified from Store)
 func (s *Int32Map) LoadOrStore(key int32, value interface{}) (actual interface{}, loaded bool) {
-	level := s.randomlevel()
-	var preds, succs [maxLevel]*int32Node
+	var (
+		level        int
+		preds, succs [maxLevel]*int32Node
+		hl           = int(atomic.LoadInt64(&s.highestLevel))
+	)
 	for {
 		nodeFound := s.findNode(key, &preds, &succs)
 		if nodeFound != nil { // indicating the key is already in the skip-list
@@ -2274,6 +2381,16 @@ func (s *Int32Map) LoadOrStore(key int32, value interface{}) (actual interface{}
 			valid                = true
 			pred, succ, prevPred *int32Node
 		)
+		if level == 0 {
+			level = s.randomlevel()
+			if level > hl {
+				// If the highest level is updated, usually means that many goroutines
+				// are inserting items. Hopefully we can find a better path in next loop.
+				// TODO(zyh): consider filling the preds if s.header[level].next == nil,
+				// but this strategy's performance is almost the same as the existing method.
+				continue
+			}
+		}
 		for layer := 0; valid && layer < level; layer++ {
 			pred = preds[layer]   // target node's previous node
 			succ = succs[layer]   // target node's next node
@@ -2310,8 +2427,11 @@ func (s *Int32Map) LoadOrStore(key int32, value interface{}) (actual interface{}
 // The loaded result is true if the value was loaded, false if stored.
 // (Modified from LoadOrStore)
 func (s *Int32Map) LoadOrStoreLazy(key int32, f func() interface{}) (actual interface{}, loaded bool) {
-	level := s.randomlevel()
-	var preds, succs [maxLevel]*int32Node
+	var (
+		level        int
+		preds, succs [maxLevel]*int32Node
+		hl           = int(atomic.LoadInt64(&s.highestLevel))
+	)
 	for {
 		nodeFound := s.findNode(key, &preds, &succs)
 		if nodeFound != nil { // indicating the key is already in the skip-list
@@ -2331,6 +2451,16 @@ func (s *Int32Map) LoadOrStoreLazy(key int32, f func() interface{}) (actual inte
 			valid                = true
 			pred, succ, prevPred *int32Node
 		)
+		if level == 0 {
+			level = s.randomlevel()
+			if level > hl {
+				// If the highest level is updated, usually means that many goroutines
+				// are inserting items. Hopefully we can find a better path in next loop.
+				// TODO(zyh): consider filling the preds if s.header[level].next == nil,
+				// but this strategy's performance is almost the same as the existing method.
+				continue
+			}
+		}
 		for layer := 0; valid && layer < level; layer++ {
 			pred = preds[layer]   // target node's previous node
 			succ = succs[layer]   // target node's next node
@@ -2739,8 +2869,11 @@ func (s *Int32MapDesc) LoadAndDelete(key int32) (value interface{}, loaded bool)
 // The loaded result is true if the value was loaded, false if stored.
 // (Modified from Store)
 func (s *Int32MapDesc) LoadOrStore(key int32, value interface{}) (actual interface{}, loaded bool) {
-	level := s.randomlevel()
-	var preds, succs [maxLevel]*int32NodeDesc
+	var (
+		level        int
+		preds, succs [maxLevel]*int32NodeDesc
+		hl           = int(atomic.LoadInt64(&s.highestLevel))
+	)
 	for {
 		nodeFound := s.findNode(key, &preds, &succs)
 		if nodeFound != nil { // indicating the key is already in the skip-list
@@ -2760,6 +2893,16 @@ func (s *Int32MapDesc) LoadOrStore(key int32, value interface{}) (actual interfa
 			valid                = true
 			pred, succ, prevPred *int32NodeDesc
 		)
+		if level == 0 {
+			level = s.randomlevel()
+			if level > hl {
+				// If the highest level is updated, usually means that many goroutines
+				// are inserting items. Hopefully we can find a better path in next loop.
+				// TODO(zyh): consider filling the preds if s.header[level].next == nil,
+				// but this strategy's performance is almost the same as the existing method.
+				continue
+			}
+		}
 		for layer := 0; valid && layer < level; layer++ {
 			pred = preds[layer]   // target node's previous node
 			succ = succs[layer]   // target node's next node
@@ -2796,8 +2939,11 @@ func (s *Int32MapDesc) LoadOrStore(key int32, value interface{}) (actual interfa
 // The loaded result is true if the value was loaded, false if stored.
 // (Modified from LoadOrStore)
 func (s *Int32MapDesc) LoadOrStoreLazy(key int32, f func() interface{}) (actual interface{}, loaded bool) {
-	level := s.randomlevel()
-	var preds, succs [maxLevel]*int32NodeDesc
+	var (
+		level        int
+		preds, succs [maxLevel]*int32NodeDesc
+		hl           = int(atomic.LoadInt64(&s.highestLevel))
+	)
 	for {
 		nodeFound := s.findNode(key, &preds, &succs)
 		if nodeFound != nil { // indicating the key is already in the skip-list
@@ -2817,6 +2963,16 @@ func (s *Int32MapDesc) LoadOrStoreLazy(key int32, f func() interface{}) (actual 
 			valid                = true
 			pred, succ, prevPred *int32NodeDesc
 		)
+		if level == 0 {
+			level = s.randomlevel()
+			if level > hl {
+				// If the highest level is updated, usually means that many goroutines
+				// are inserting items. Hopefully we can find a better path in next loop.
+				// TODO(zyh): consider filling the preds if s.header[level].next == nil,
+				// but this strategy's performance is almost the same as the existing method.
+				continue
+			}
+		}
 		for layer := 0; valid && layer < level; layer++ {
 			pred = preds[layer]   // target node's previous node
 			succ = succs[layer]   // target node's next node
@@ -3225,8 +3381,11 @@ func (s *Int16Map) LoadAndDelete(key int16) (value interface{}, loaded bool) {
 // The loaded result is true if the value was loaded, false if stored.
 // (Modified from Store)
 func (s *Int16Map) LoadOrStore(key int16, value interface{}) (actual interface{}, loaded bool) {
-	level := s.randomlevel()
-	var preds, succs [maxLevel]*int16Node
+	var (
+		level        int
+		preds, succs [maxLevel]*int16Node
+		hl           = int(atomic.LoadInt64(&s.highestLevel))
+	)
 	for {
 		nodeFound := s.findNode(key, &preds, &succs)
 		if nodeFound != nil { // indicating the key is already in the skip-list
@@ -3246,6 +3405,16 @@ func (s *Int16Map) LoadOrStore(key int16, value interface{}) (actual interface{}
 			valid                = true
 			pred, succ, prevPred *int16Node
 		)
+		if level == 0 {
+			level = s.randomlevel()
+			if level > hl {
+				// If the highest level is updated, usually means that many goroutines
+				// are inserting items. Hopefully we can find a better path in next loop.
+				// TODO(zyh): consider filling the preds if s.header[level].next == nil,
+				// but this strategy's performance is almost the same as the existing method.
+				continue
+			}
+		}
 		for layer := 0; valid && layer < level; layer++ {
 			pred = preds[layer]   // target node's previous node
 			succ = succs[layer]   // target node's next node
@@ -3282,8 +3451,11 @@ func (s *Int16Map) LoadOrStore(key int16, value interface{}) (actual interface{}
 // The loaded result is true if the value was loaded, false if stored.
 // (Modified from LoadOrStore)
 func (s *Int16Map) LoadOrStoreLazy(key int16, f func() interface{}) (actual interface{}, loaded bool) {
-	level := s.randomlevel()
-	var preds, succs [maxLevel]*int16Node
+	var (
+		level        int
+		preds, succs [maxLevel]*int16Node
+		hl           = int(atomic.LoadInt64(&s.highestLevel))
+	)
 	for {
 		nodeFound := s.findNode(key, &preds, &succs)
 		if nodeFound != nil { // indicating the key is already in the skip-list
@@ -3303,6 +3475,16 @@ func (s *Int16Map) LoadOrStoreLazy(key int16, f func() interface{}) (actual inte
 			valid                = true
 			pred, succ, prevPred *int16Node
 		)
+		if level == 0 {
+			level = s.randomlevel()
+			if level > hl {
+				// If the highest level is updated, usually means that many goroutines
+				// are inserting items. Hopefully we can find a better path in next loop.
+				// TODO(zyh): consider filling the preds if s.header[level].next == nil,
+				// but this strategy's performance is almost the same as the existing method.
+				continue
+			}
+		}
 		for layer := 0; valid && layer < level; layer++ {
 			pred = preds[layer]   // target node's previous node
 			succ = succs[layer]   // target node's next node
@@ -3711,8 +3893,11 @@ func (s *Int16MapDesc) LoadAndDelete(key int16) (value interface{}, loaded bool)
 // The loaded result is true if the value was loaded, false if stored.
 // (Modified from Store)
 func (s *Int16MapDesc) LoadOrStore(key int16, value interface{}) (actual interface{}, loaded bool) {
-	level := s.randomlevel()
-	var preds, succs [maxLevel]*int16NodeDesc
+	var (
+		level        int
+		preds, succs [maxLevel]*int16NodeDesc
+		hl           = int(atomic.LoadInt64(&s.highestLevel))
+	)
 	for {
 		nodeFound := s.findNode(key, &preds, &succs)
 		if nodeFound != nil { // indicating the key is already in the skip-list
@@ -3732,6 +3917,16 @@ func (s *Int16MapDesc) LoadOrStore(key int16, value interface{}) (actual interfa
 			valid                = true
 			pred, succ, prevPred *int16NodeDesc
 		)
+		if level == 0 {
+			level = s.randomlevel()
+			if level > hl {
+				// If the highest level is updated, usually means that many goroutines
+				// are inserting items. Hopefully we can find a better path in next loop.
+				// TODO(zyh): consider filling the preds if s.header[level].next == nil,
+				// but this strategy's performance is almost the same as the existing method.
+				continue
+			}
+		}
 		for layer := 0; valid && layer < level; layer++ {
 			pred = preds[layer]   // target node's previous node
 			succ = succs[layer]   // target node's next node
@@ -3768,8 +3963,11 @@ func (s *Int16MapDesc) LoadOrStore(key int16, value interface{}) (actual interfa
 // The loaded result is true if the value was loaded, false if stored.
 // (Modified from LoadOrStore)
 func (s *Int16MapDesc) LoadOrStoreLazy(key int16, f func() interface{}) (actual interface{}, loaded bool) {
-	level := s.randomlevel()
-	var preds, succs [maxLevel]*int16NodeDesc
+	var (
+		level        int
+		preds, succs [maxLevel]*int16NodeDesc
+		hl           = int(atomic.LoadInt64(&s.highestLevel))
+	)
 	for {
 		nodeFound := s.findNode(key, &preds, &succs)
 		if nodeFound != nil { // indicating the key is already in the skip-list
@@ -3789,6 +3987,16 @@ func (s *Int16MapDesc) LoadOrStoreLazy(key int16, f func() interface{}) (actual 
 			valid                = true
 			pred, succ, prevPred *int16NodeDesc
 		)
+		if level == 0 {
+			level = s.randomlevel()
+			if level > hl {
+				// If the highest level is updated, usually means that many goroutines
+				// are inserting items. Hopefully we can find a better path in next loop.
+				// TODO(zyh): consider filling the preds if s.header[level].next == nil,
+				// but this strategy's performance is almost the same as the existing method.
+				continue
+			}
+		}
 		for layer := 0; valid && layer < level; layer++ {
 			pred = preds[layer]   // target node's previous node
 			succ = succs[layer]   // target node's next node
@@ -4197,8 +4405,11 @@ func (s *IntMap) LoadAndDelete(key int) (value interface{}, loaded bool) {
 // The loaded result is true if the value was loaded, false if stored.
 // (Modified from Store)
 func (s *IntMap) LoadOrStore(key int, value interface{}) (actual interface{}, loaded bool) {
-	level := s.randomlevel()
-	var preds, succs [maxLevel]*intNode
+	var (
+		level        int
+		preds, succs [maxLevel]*intNode
+		hl           = int(atomic.LoadInt64(&s.highestLevel))
+	)
 	for {
 		nodeFound := s.findNode(key, &preds, &succs)
 		if nodeFound != nil { // indicating the key is already in the skip-list
@@ -4218,6 +4429,16 @@ func (s *IntMap) LoadOrStore(key int, value interface{}) (actual interface{}, lo
 			valid                = true
 			pred, succ, prevPred *intNode
 		)
+		if level == 0 {
+			level = s.randomlevel()
+			if level > hl {
+				// If the highest level is updated, usually means that many goroutines
+				// are inserting items. Hopefully we can find a better path in next loop.
+				// TODO(zyh): consider filling the preds if s.header[level].next == nil,
+				// but this strategy's performance is almost the same as the existing method.
+				continue
+			}
+		}
 		for layer := 0; valid && layer < level; layer++ {
 			pred = preds[layer]   // target node's previous node
 			succ = succs[layer]   // target node's next node
@@ -4254,8 +4475,11 @@ func (s *IntMap) LoadOrStore(key int, value interface{}) (actual interface{}, lo
 // The loaded result is true if the value was loaded, false if stored.
 // (Modified from LoadOrStore)
 func (s *IntMap) LoadOrStoreLazy(key int, f func() interface{}) (actual interface{}, loaded bool) {
-	level := s.randomlevel()
-	var preds, succs [maxLevel]*intNode
+	var (
+		level        int
+		preds, succs [maxLevel]*intNode
+		hl           = int(atomic.LoadInt64(&s.highestLevel))
+	)
 	for {
 		nodeFound := s.findNode(key, &preds, &succs)
 		if nodeFound != nil { // indicating the key is already in the skip-list
@@ -4275,6 +4499,16 @@ func (s *IntMap) LoadOrStoreLazy(key int, f func() interface{}) (actual interfac
 			valid                = true
 			pred, succ, prevPred *intNode
 		)
+		if level == 0 {
+			level = s.randomlevel()
+			if level > hl {
+				// If the highest level is updated, usually means that many goroutines
+				// are inserting items. Hopefully we can find a better path in next loop.
+				// TODO(zyh): consider filling the preds if s.header[level].next == nil,
+				// but this strategy's performance is almost the same as the existing method.
+				continue
+			}
+		}
 		for layer := 0; valid && layer < level; layer++ {
 			pred = preds[layer]   // target node's previous node
 			succ = succs[layer]   // target node's next node
@@ -4683,8 +4917,11 @@ func (s *IntMapDesc) LoadAndDelete(key int) (value interface{}, loaded bool) {
 // The loaded result is true if the value was loaded, false if stored.
 // (Modified from Store)
 func (s *IntMapDesc) LoadOrStore(key int, value interface{}) (actual interface{}, loaded bool) {
-	level := s.randomlevel()
-	var preds, succs [maxLevel]*intNodeDesc
+	var (
+		level        int
+		preds, succs [maxLevel]*intNodeDesc
+		hl           = int(atomic.LoadInt64(&s.highestLevel))
+	)
 	for {
 		nodeFound := s.findNode(key, &preds, &succs)
 		if nodeFound != nil { // indicating the key is already in the skip-list
@@ -4704,6 +4941,16 @@ func (s *IntMapDesc) LoadOrStore(key int, value interface{}) (actual interface{}
 			valid                = true
 			pred, succ, prevPred *intNodeDesc
 		)
+		if level == 0 {
+			level = s.randomlevel()
+			if level > hl {
+				// If the highest level is updated, usually means that many goroutines
+				// are inserting items. Hopefully we can find a better path in next loop.
+				// TODO(zyh): consider filling the preds if s.header[level].next == nil,
+				// but this strategy's performance is almost the same as the existing method.
+				continue
+			}
+		}
 		for layer := 0; valid && layer < level; layer++ {
 			pred = preds[layer]   // target node's previous node
 			succ = succs[layer]   // target node's next node
@@ -4740,8 +4987,11 @@ func (s *IntMapDesc) LoadOrStore(key int, value interface{}) (actual interface{}
 // The loaded result is true if the value was loaded, false if stored.
 // (Modified from LoadOrStore)
 func (s *IntMapDesc) LoadOrStoreLazy(key int, f func() interface{}) (actual interface{}, loaded bool) {
-	level := s.randomlevel()
-	var preds, succs [maxLevel]*intNodeDesc
+	var (
+		level        int
+		preds, succs [maxLevel]*intNodeDesc
+		hl           = int(atomic.LoadInt64(&s.highestLevel))
+	)
 	for {
 		nodeFound := s.findNode(key, &preds, &succs)
 		if nodeFound != nil { // indicating the key is already in the skip-list
@@ -4761,6 +5011,16 @@ func (s *IntMapDesc) LoadOrStoreLazy(key int, f func() interface{}) (actual inte
 			valid                = true
 			pred, succ, prevPred *intNodeDesc
 		)
+		if level == 0 {
+			level = s.randomlevel()
+			if level > hl {
+				// If the highest level is updated, usually means that many goroutines
+				// are inserting items. Hopefully we can find a better path in next loop.
+				// TODO(zyh): consider filling the preds if s.header[level].next == nil,
+				// but this strategy's performance is almost the same as the existing method.
+				continue
+			}
+		}
 		for layer := 0; valid && layer < level; layer++ {
 			pred = preds[layer]   // target node's previous node
 			succ = succs[layer]   // target node's next node
@@ -5169,8 +5429,11 @@ func (s *Uint64Map) LoadAndDelete(key uint64) (value interface{}, loaded bool) {
 // The loaded result is true if the value was loaded, false if stored.
 // (Modified from Store)
 func (s *Uint64Map) LoadOrStore(key uint64, value interface{}) (actual interface{}, loaded bool) {
-	level := s.randomlevel()
-	var preds, succs [maxLevel]*uint64Node
+	var (
+		level        int
+		preds, succs [maxLevel]*uint64Node
+		hl           = int(atomic.LoadInt64(&s.highestLevel))
+	)
 	for {
 		nodeFound := s.findNode(key, &preds, &succs)
 		if nodeFound != nil { // indicating the key is already in the skip-list
@@ -5190,6 +5453,16 @@ func (s *Uint64Map) LoadOrStore(key uint64, value interface{}) (actual interface
 			valid                = true
 			pred, succ, prevPred *uint64Node
 		)
+		if level == 0 {
+			level = s.randomlevel()
+			if level > hl {
+				// If the highest level is updated, usually means that many goroutines
+				// are inserting items. Hopefully we can find a better path in next loop.
+				// TODO(zyh): consider filling the preds if s.header[level].next == nil,
+				// but this strategy's performance is almost the same as the existing method.
+				continue
+			}
+		}
 		for layer := 0; valid && layer < level; layer++ {
 			pred = preds[layer]   // target node's previous node
 			succ = succs[layer]   // target node's next node
@@ -5226,8 +5499,11 @@ func (s *Uint64Map) LoadOrStore(key uint64, value interface{}) (actual interface
 // The loaded result is true if the value was loaded, false if stored.
 // (Modified from LoadOrStore)
 func (s *Uint64Map) LoadOrStoreLazy(key uint64, f func() interface{}) (actual interface{}, loaded bool) {
-	level := s.randomlevel()
-	var preds, succs [maxLevel]*uint64Node
+	var (
+		level        int
+		preds, succs [maxLevel]*uint64Node
+		hl           = int(atomic.LoadInt64(&s.highestLevel))
+	)
 	for {
 		nodeFound := s.findNode(key, &preds, &succs)
 		if nodeFound != nil { // indicating the key is already in the skip-list
@@ -5247,6 +5523,16 @@ func (s *Uint64Map) LoadOrStoreLazy(key uint64, f func() interface{}) (actual in
 			valid                = true
 			pred, succ, prevPred *uint64Node
 		)
+		if level == 0 {
+			level = s.randomlevel()
+			if level > hl {
+				// If the highest level is updated, usually means that many goroutines
+				// are inserting items. Hopefully we can find a better path in next loop.
+				// TODO(zyh): consider filling the preds if s.header[level].next == nil,
+				// but this strategy's performance is almost the same as the existing method.
+				continue
+			}
+		}
 		for layer := 0; valid && layer < level; layer++ {
 			pred = preds[layer]   // target node's previous node
 			succ = succs[layer]   // target node's next node
@@ -5655,8 +5941,11 @@ func (s *Uint64MapDesc) LoadAndDelete(key uint64) (value interface{}, loaded boo
 // The loaded result is true if the value was loaded, false if stored.
 // (Modified from Store)
 func (s *Uint64MapDesc) LoadOrStore(key uint64, value interface{}) (actual interface{}, loaded bool) {
-	level := s.randomlevel()
-	var preds, succs [maxLevel]*uint64NodeDesc
+	var (
+		level        int
+		preds, succs [maxLevel]*uint64NodeDesc
+		hl           = int(atomic.LoadInt64(&s.highestLevel))
+	)
 	for {
 		nodeFound := s.findNode(key, &preds, &succs)
 		if nodeFound != nil { // indicating the key is already in the skip-list
@@ -5676,6 +5965,16 @@ func (s *Uint64MapDesc) LoadOrStore(key uint64, value interface{}) (actual inter
 			valid                = true
 			pred, succ, prevPred *uint64NodeDesc
 		)
+		if level == 0 {
+			level = s.randomlevel()
+			if level > hl {
+				// If the highest level is updated, usually means that many goroutines
+				// are inserting items. Hopefully we can find a better path in next loop.
+				// TODO(zyh): consider filling the preds if s.header[level].next == nil,
+				// but this strategy's performance is almost the same as the existing method.
+				continue
+			}
+		}
 		for layer := 0; valid && layer < level; layer++ {
 			pred = preds[layer]   // target node's previous node
 			succ = succs[layer]   // target node's next node
@@ -5712,8 +6011,11 @@ func (s *Uint64MapDesc) LoadOrStore(key uint64, value interface{}) (actual inter
 // The loaded result is true if the value was loaded, false if stored.
 // (Modified from LoadOrStore)
 func (s *Uint64MapDesc) LoadOrStoreLazy(key uint64, f func() interface{}) (actual interface{}, loaded bool) {
-	level := s.randomlevel()
-	var preds, succs [maxLevel]*uint64NodeDesc
+	var (
+		level        int
+		preds, succs [maxLevel]*uint64NodeDesc
+		hl           = int(atomic.LoadInt64(&s.highestLevel))
+	)
 	for {
 		nodeFound := s.findNode(key, &preds, &succs)
 		if nodeFound != nil { // indicating the key is already in the skip-list
@@ -5733,6 +6035,16 @@ func (s *Uint64MapDesc) LoadOrStoreLazy(key uint64, f func() interface{}) (actua
 			valid                = true
 			pred, succ, prevPred *uint64NodeDesc
 		)
+		if level == 0 {
+			level = s.randomlevel()
+			if level > hl {
+				// If the highest level is updated, usually means that many goroutines
+				// are inserting items. Hopefully we can find a better path in next loop.
+				// TODO(zyh): consider filling the preds if s.header[level].next == nil,
+				// but this strategy's performance is almost the same as the existing method.
+				continue
+			}
+		}
 		for layer := 0; valid && layer < level; layer++ {
 			pred = preds[layer]   // target node's previous node
 			succ = succs[layer]   // target node's next node
@@ -6141,8 +6453,11 @@ func (s *Uint32Map) LoadAndDelete(key uint32) (value interface{}, loaded bool) {
 // The loaded result is true if the value was loaded, false if stored.
 // (Modified from Store)
 func (s *Uint32Map) LoadOrStore(key uint32, value interface{}) (actual interface{}, loaded bool) {
-	level := s.randomlevel()
-	var preds, succs [maxLevel]*uint32Node
+	var (
+		level        int
+		preds, succs [maxLevel]*uint32Node
+		hl           = int(atomic.LoadInt64(&s.highestLevel))
+	)
 	for {
 		nodeFound := s.findNode(key, &preds, &succs)
 		if nodeFound != nil { // indicating the key is already in the skip-list
@@ -6162,6 +6477,16 @@ func (s *Uint32Map) LoadOrStore(key uint32, value interface{}) (actual interface
 			valid                = true
 			pred, succ, prevPred *uint32Node
 		)
+		if level == 0 {
+			level = s.randomlevel()
+			if level > hl {
+				// If the highest level is updated, usually means that many goroutines
+				// are inserting items. Hopefully we can find a better path in next loop.
+				// TODO(zyh): consider filling the preds if s.header[level].next == nil,
+				// but this strategy's performance is almost the same as the existing method.
+				continue
+			}
+		}
 		for layer := 0; valid && layer < level; layer++ {
 			pred = preds[layer]   // target node's previous node
 			succ = succs[layer]   // target node's next node
@@ -6198,8 +6523,11 @@ func (s *Uint32Map) LoadOrStore(key uint32, value interface{}) (actual interface
 // The loaded result is true if the value was loaded, false if stored.
 // (Modified from LoadOrStore)
 func (s *Uint32Map) LoadOrStoreLazy(key uint32, f func() interface{}) (actual interface{}, loaded bool) {
-	level := s.randomlevel()
-	var preds, succs [maxLevel]*uint32Node
+	var (
+		level        int
+		preds, succs [maxLevel]*uint32Node
+		hl           = int(atomic.LoadInt64(&s.highestLevel))
+	)
 	for {
 		nodeFound := s.findNode(key, &preds, &succs)
 		if nodeFound != nil { // indicating the key is already in the skip-list
@@ -6219,6 +6547,16 @@ func (s *Uint32Map) LoadOrStoreLazy(key uint32, f func() interface{}) (actual in
 			valid                = true
 			pred, succ, prevPred *uint32Node
 		)
+		if level == 0 {
+			level = s.randomlevel()
+			if level > hl {
+				// If the highest level is updated, usually means that many goroutines
+				// are inserting items. Hopefully we can find a better path in next loop.
+				// TODO(zyh): consider filling the preds if s.header[level].next == nil,
+				// but this strategy's performance is almost the same as the existing method.
+				continue
+			}
+		}
 		for layer := 0; valid && layer < level; layer++ {
 			pred = preds[layer]   // target node's previous node
 			succ = succs[layer]   // target node's next node
@@ -6627,8 +6965,11 @@ func (s *Uint32MapDesc) LoadAndDelete(key uint32) (value interface{}, loaded boo
 // The loaded result is true if the value was loaded, false if stored.
 // (Modified from Store)
 func (s *Uint32MapDesc) LoadOrStore(key uint32, value interface{}) (actual interface{}, loaded bool) {
-	level := s.randomlevel()
-	var preds, succs [maxLevel]*uint32NodeDesc
+	var (
+		level        int
+		preds, succs [maxLevel]*uint32NodeDesc
+		hl           = int(atomic.LoadInt64(&s.highestLevel))
+	)
 	for {
 		nodeFound := s.findNode(key, &preds, &succs)
 		if nodeFound != nil { // indicating the key is already in the skip-list
@@ -6648,6 +6989,16 @@ func (s *Uint32MapDesc) LoadOrStore(key uint32, value interface{}) (actual inter
 			valid                = true
 			pred, succ, prevPred *uint32NodeDesc
 		)
+		if level == 0 {
+			level = s.randomlevel()
+			if level > hl {
+				// If the highest level is updated, usually means that many goroutines
+				// are inserting items. Hopefully we can find a better path in next loop.
+				// TODO(zyh): consider filling the preds if s.header[level].next == nil,
+				// but this strategy's performance is almost the same as the existing method.
+				continue
+			}
+		}
 		for layer := 0; valid && layer < level; layer++ {
 			pred = preds[layer]   // target node's previous node
 			succ = succs[layer]   // target node's next node
@@ -6684,8 +7035,11 @@ func (s *Uint32MapDesc) LoadOrStore(key uint32, value interface{}) (actual inter
 // The loaded result is true if the value was loaded, false if stored.
 // (Modified from LoadOrStore)
 func (s *Uint32MapDesc) LoadOrStoreLazy(key uint32, f func() interface{}) (actual interface{}, loaded bool) {
-	level := s.randomlevel()
-	var preds, succs [maxLevel]*uint32NodeDesc
+	var (
+		level        int
+		preds, succs [maxLevel]*uint32NodeDesc
+		hl           = int(atomic.LoadInt64(&s.highestLevel))
+	)
 	for {
 		nodeFound := s.findNode(key, &preds, &succs)
 		if nodeFound != nil { // indicating the key is already in the skip-list
@@ -6705,6 +7059,16 @@ func (s *Uint32MapDesc) LoadOrStoreLazy(key uint32, f func() interface{}) (actua
 			valid                = true
 			pred, succ, prevPred *uint32NodeDesc
 		)
+		if level == 0 {
+			level = s.randomlevel()
+			if level > hl {
+				// If the highest level is updated, usually means that many goroutines
+				// are inserting items. Hopefully we can find a better path in next loop.
+				// TODO(zyh): consider filling the preds if s.header[level].next == nil,
+				// but this strategy's performance is almost the same as the existing method.
+				continue
+			}
+		}
 		for layer := 0; valid && layer < level; layer++ {
 			pred = preds[layer]   // target node's previous node
 			succ = succs[layer]   // target node's next node
@@ -7113,8 +7477,11 @@ func (s *Uint16Map) LoadAndDelete(key uint16) (value interface{}, loaded bool) {
 // The loaded result is true if the value was loaded, false if stored.
 // (Modified from Store)
 func (s *Uint16Map) LoadOrStore(key uint16, value interface{}) (actual interface{}, loaded bool) {
-	level := s.randomlevel()
-	var preds, succs [maxLevel]*uint16Node
+	var (
+		level        int
+		preds, succs [maxLevel]*uint16Node
+		hl           = int(atomic.LoadInt64(&s.highestLevel))
+	)
 	for {
 		nodeFound := s.findNode(key, &preds, &succs)
 		if nodeFound != nil { // indicating the key is already in the skip-list
@@ -7134,6 +7501,16 @@ func (s *Uint16Map) LoadOrStore(key uint16, value interface{}) (actual interface
 			valid                = true
 			pred, succ, prevPred *uint16Node
 		)
+		if level == 0 {
+			level = s.randomlevel()
+			if level > hl {
+				// If the highest level is updated, usually means that many goroutines
+				// are inserting items. Hopefully we can find a better path in next loop.
+				// TODO(zyh): consider filling the preds if s.header[level].next == nil,
+				// but this strategy's performance is almost the same as the existing method.
+				continue
+			}
+		}
 		for layer := 0; valid && layer < level; layer++ {
 			pred = preds[layer]   // target node's previous node
 			succ = succs[layer]   // target node's next node
@@ -7170,8 +7547,11 @@ func (s *Uint16Map) LoadOrStore(key uint16, value interface{}) (actual interface
 // The loaded result is true if the value was loaded, false if stored.
 // (Modified from LoadOrStore)
 func (s *Uint16Map) LoadOrStoreLazy(key uint16, f func() interface{}) (actual interface{}, loaded bool) {
-	level := s.randomlevel()
-	var preds, succs [maxLevel]*uint16Node
+	var (
+		level        int
+		preds, succs [maxLevel]*uint16Node
+		hl           = int(atomic.LoadInt64(&s.highestLevel))
+	)
 	for {
 		nodeFound := s.findNode(key, &preds, &succs)
 		if nodeFound != nil { // indicating the key is already in the skip-list
@@ -7191,6 +7571,16 @@ func (s *Uint16Map) LoadOrStoreLazy(key uint16, f func() interface{}) (actual in
 			valid                = true
 			pred, succ, prevPred *uint16Node
 		)
+		if level == 0 {
+			level = s.randomlevel()
+			if level > hl {
+				// If the highest level is updated, usually means that many goroutines
+				// are inserting items. Hopefully we can find a better path in next loop.
+				// TODO(zyh): consider filling the preds if s.header[level].next == nil,
+				// but this strategy's performance is almost the same as the existing method.
+				continue
+			}
+		}
 		for layer := 0; valid && layer < level; layer++ {
 			pred = preds[layer]   // target node's previous node
 			succ = succs[layer]   // target node's next node
@@ -7599,8 +7989,11 @@ func (s *Uint16MapDesc) LoadAndDelete(key uint16) (value interface{}, loaded boo
 // The loaded result is true if the value was loaded, false if stored.
 // (Modified from Store)
 func (s *Uint16MapDesc) LoadOrStore(key uint16, value interface{}) (actual interface{}, loaded bool) {
-	level := s.randomlevel()
-	var preds, succs [maxLevel]*uint16NodeDesc
+	var (
+		level        int
+		preds, succs [maxLevel]*uint16NodeDesc
+		hl           = int(atomic.LoadInt64(&s.highestLevel))
+	)
 	for {
 		nodeFound := s.findNode(key, &preds, &succs)
 		if nodeFound != nil { // indicating the key is already in the skip-list
@@ -7620,6 +8013,16 @@ func (s *Uint16MapDesc) LoadOrStore(key uint16, value interface{}) (actual inter
 			valid                = true
 			pred, succ, prevPred *uint16NodeDesc
 		)
+		if level == 0 {
+			level = s.randomlevel()
+			if level > hl {
+				// If the highest level is updated, usually means that many goroutines
+				// are inserting items. Hopefully we can find a better path in next loop.
+				// TODO(zyh): consider filling the preds if s.header[level].next == nil,
+				// but this strategy's performance is almost the same as the existing method.
+				continue
+			}
+		}
 		for layer := 0; valid && layer < level; layer++ {
 			pred = preds[layer]   // target node's previous node
 			succ = succs[layer]   // target node's next node
@@ -7656,8 +8059,11 @@ func (s *Uint16MapDesc) LoadOrStore(key uint16, value interface{}) (actual inter
 // The loaded result is true if the value was loaded, false if stored.
 // (Modified from LoadOrStore)
 func (s *Uint16MapDesc) LoadOrStoreLazy(key uint16, f func() interface{}) (actual interface{}, loaded bool) {
-	level := s.randomlevel()
-	var preds, succs [maxLevel]*uint16NodeDesc
+	var (
+		level        int
+		preds, succs [maxLevel]*uint16NodeDesc
+		hl           = int(atomic.LoadInt64(&s.highestLevel))
+	)
 	for {
 		nodeFound := s.findNode(key, &preds, &succs)
 		if nodeFound != nil { // indicating the key is already in the skip-list
@@ -7677,6 +8083,16 @@ func (s *Uint16MapDesc) LoadOrStoreLazy(key uint16, f func() interface{}) (actua
 			valid                = true
 			pred, succ, prevPred *uint16NodeDesc
 		)
+		if level == 0 {
+			level = s.randomlevel()
+			if level > hl {
+				// If the highest level is updated, usually means that many goroutines
+				// are inserting items. Hopefully we can find a better path in next loop.
+				// TODO(zyh): consider filling the preds if s.header[level].next == nil,
+				// but this strategy's performance is almost the same as the existing method.
+				continue
+			}
+		}
 		for layer := 0; valid && layer < level; layer++ {
 			pred = preds[layer]   // target node's previous node
 			succ = succs[layer]   // target node's next node
@@ -8085,8 +8501,11 @@ func (s *UintMap) LoadAndDelete(key uint) (value interface{}, loaded bool) {
 // The loaded result is true if the value was loaded, false if stored.
 // (Modified from Store)
 func (s *UintMap) LoadOrStore(key uint, value interface{}) (actual interface{}, loaded bool) {
-	level := s.randomlevel()
-	var preds, succs [maxLevel]*uintNode
+	var (
+		level        int
+		preds, succs [maxLevel]*uintNode
+		hl           = int(atomic.LoadInt64(&s.highestLevel))
+	)
 	for {
 		nodeFound := s.findNode(key, &preds, &succs)
 		if nodeFound != nil { // indicating the key is already in the skip-list
@@ -8106,6 +8525,16 @@ func (s *UintMap) LoadOrStore(key uint, value interface{}) (actual interface{}, 
 			valid                = true
 			pred, succ, prevPred *uintNode
 		)
+		if level == 0 {
+			level = s.randomlevel()
+			if level > hl {
+				// If the highest level is updated, usually means that many goroutines
+				// are inserting items. Hopefully we can find a better path in next loop.
+				// TODO(zyh): consider filling the preds if s.header[level].next == nil,
+				// but this strategy's performance is almost the same as the existing method.
+				continue
+			}
+		}
 		for layer := 0; valid && layer < level; layer++ {
 			pred = preds[layer]   // target node's previous node
 			succ = succs[layer]   // target node's next node
@@ -8142,8 +8571,11 @@ func (s *UintMap) LoadOrStore(key uint, value interface{}) (actual interface{}, 
 // The loaded result is true if the value was loaded, false if stored.
 // (Modified from LoadOrStore)
 func (s *UintMap) LoadOrStoreLazy(key uint, f func() interface{}) (actual interface{}, loaded bool) {
-	level := s.randomlevel()
-	var preds, succs [maxLevel]*uintNode
+	var (
+		level        int
+		preds, succs [maxLevel]*uintNode
+		hl           = int(atomic.LoadInt64(&s.highestLevel))
+	)
 	for {
 		nodeFound := s.findNode(key, &preds, &succs)
 		if nodeFound != nil { // indicating the key is already in the skip-list
@@ -8163,6 +8595,16 @@ func (s *UintMap) LoadOrStoreLazy(key uint, f func() interface{}) (actual interf
 			valid                = true
 			pred, succ, prevPred *uintNode
 		)
+		if level == 0 {
+			level = s.randomlevel()
+			if level > hl {
+				// If the highest level is updated, usually means that many goroutines
+				// are inserting items. Hopefully we can find a better path in next loop.
+				// TODO(zyh): consider filling the preds if s.header[level].next == nil,
+				// but this strategy's performance is almost the same as the existing method.
+				continue
+			}
+		}
 		for layer := 0; valid && layer < level; layer++ {
 			pred = preds[layer]   // target node's previous node
 			succ = succs[layer]   // target node's next node
@@ -8571,8 +9013,11 @@ func (s *UintMapDesc) LoadAndDelete(key uint) (value interface{}, loaded bool) {
 // The loaded result is true if the value was loaded, false if stored.
 // (Modified from Store)
 func (s *UintMapDesc) LoadOrStore(key uint, value interface{}) (actual interface{}, loaded bool) {
-	level := s.randomlevel()
-	var preds, succs [maxLevel]*uintNodeDesc
+	var (
+		level        int
+		preds, succs [maxLevel]*uintNodeDesc
+		hl           = int(atomic.LoadInt64(&s.highestLevel))
+	)
 	for {
 		nodeFound := s.findNode(key, &preds, &succs)
 		if nodeFound != nil { // indicating the key is already in the skip-list
@@ -8592,6 +9037,16 @@ func (s *UintMapDesc) LoadOrStore(key uint, value interface{}) (actual interface
 			valid                = true
 			pred, succ, prevPred *uintNodeDesc
 		)
+		if level == 0 {
+			level = s.randomlevel()
+			if level > hl {
+				// If the highest level is updated, usually means that many goroutines
+				// are inserting items. Hopefully we can find a better path in next loop.
+				// TODO(zyh): consider filling the preds if s.header[level].next == nil,
+				// but this strategy's performance is almost the same as the existing method.
+				continue
+			}
+		}
 		for layer := 0; valid && layer < level; layer++ {
 			pred = preds[layer]   // target node's previous node
 			succ = succs[layer]   // target node's next node
@@ -8628,8 +9083,11 @@ func (s *UintMapDesc) LoadOrStore(key uint, value interface{}) (actual interface
 // The loaded result is true if the value was loaded, false if stored.
 // (Modified from LoadOrStore)
 func (s *UintMapDesc) LoadOrStoreLazy(key uint, f func() interface{}) (actual interface{}, loaded bool) {
-	level := s.randomlevel()
-	var preds, succs [maxLevel]*uintNodeDesc
+	var (
+		level        int
+		preds, succs [maxLevel]*uintNodeDesc
+		hl           = int(atomic.LoadInt64(&s.highestLevel))
+	)
 	for {
 		nodeFound := s.findNode(key, &preds, &succs)
 		if nodeFound != nil { // indicating the key is already in the skip-list
@@ -8649,6 +9107,16 @@ func (s *UintMapDesc) LoadOrStoreLazy(key uint, f func() interface{}) (actual in
 			valid                = true
 			pred, succ, prevPred *uintNodeDesc
 		)
+		if level == 0 {
+			level = s.randomlevel()
+			if level > hl {
+				// If the highest level is updated, usually means that many goroutines
+				// are inserting items. Hopefully we can find a better path in next loop.
+				// TODO(zyh): consider filling the preds if s.header[level].next == nil,
+				// but this strategy's performance is almost the same as the existing method.
+				continue
+			}
+		}
 		for layer := 0; valid && layer < level; layer++ {
 			pred = preds[layer]   // target node's previous node
 			succ = succs[layer]   // target node's next node
@@ -9054,8 +9522,11 @@ func (s *StringMap) LoadAndDelete(key string) (value interface{}, loaded bool) {
 // The loaded result is true if the value was loaded, false if stored.
 // (Modified from Store)
 func (s *StringMap) LoadOrStore(key string, value interface{}) (actual interface{}, loaded bool) {
-	level := s.randomlevel()
-	var preds, succs [maxLevel]*stringNode
+	var (
+		level        int
+		preds, succs [maxLevel]*stringNode
+		hl           = int(atomic.LoadInt64(&s.highestLevel))
+	)
 	for {
 		nodeFound := s.findNode(key, &preds, &succs)
 		if nodeFound != nil { // indicating the key is already in the skip-list
@@ -9075,6 +9546,16 @@ func (s *StringMap) LoadOrStore(key string, value interface{}) (actual interface
 			valid                = true
 			pred, succ, prevPred *stringNode
 		)
+		if level == 0 {
+			level = s.randomlevel()
+			if level > hl {
+				// If the highest level is updated, usually means that many goroutines
+				// are inserting items. Hopefully we can find a better path in next loop.
+				// TODO(zyh): consider filling the preds if s.header[level].next == nil,
+				// but this strategy's performance is almost the same as the existing method.
+				continue
+			}
+		}
 		for layer := 0; valid && layer < level; layer++ {
 			pred = preds[layer]   // target node's previous node
 			succ = succs[layer]   // target node's next node
@@ -9111,8 +9592,11 @@ func (s *StringMap) LoadOrStore(key string, value interface{}) (actual interface
 // The loaded result is true if the value was loaded, false if stored.
 // (Modified from LoadOrStore)
 func (s *StringMap) LoadOrStoreLazy(key string, f func() interface{}) (actual interface{}, loaded bool) {
-	level := s.randomlevel()
-	var preds, succs [maxLevel]*stringNode
+	var (
+		level        int
+		preds, succs [maxLevel]*stringNode
+		hl           = int(atomic.LoadInt64(&s.highestLevel))
+	)
 	for {
 		nodeFound := s.findNode(key, &preds, &succs)
 		if nodeFound != nil { // indicating the key is already in the skip-list
@@ -9132,6 +9616,16 @@ func (s *StringMap) LoadOrStoreLazy(key string, f func() interface{}) (actual in
 			valid                = true
 			pred, succ, prevPred *stringNode
 		)
+		if level == 0 {
+			level = s.randomlevel()
+			if level > hl {
+				// If the highest level is updated, usually means that many goroutines
+				// are inserting items. Hopefully we can find a better path in next loop.
+				// TODO(zyh): consider filling the preds if s.header[level].next == nil,
+				// but this strategy's performance is almost the same as the existing method.
+				continue
+			}
+		}
 		for layer := 0; valid && layer < level; layer++ {
 			pred = preds[layer]   // target node's previous node
 			succ = succs[layer]   // target node's next node


### PR DESCRIPTION
The key problem is that the `LoadOrStore` uses an outdated highest level to search the skip list, if the new generated level(say `newLevel`) is bigger than the outdated highest level(say `oldLevel`), all slots in the slices `preds[newLevel-oldLevel:newLevel]` are nil, the function will panic.

The solution is that if the `newLevel` has updated the highest level, we can just continue the loop, and find a new path. At this time, the latest highest level used by the `findNode` is always bigger than or equal to the newLevel, the function won't panic.

```
name                            old time/op  new time/op  delta
LoadOrStoreExist-16             4.43ns ±11%  1.06ns ±21%  -76.05%  (p=0.000 n=10+10)
LoadOrStoreLazyExist-16         4.61ns ± 6%  1.16ns ± 0%  -74.90%  (p=0.000 n=9+7)
LoadOrStoreExistSingle-16       37.5ns ± 6%  10.3ns ± 0%  -72.61%  (p=0.000 n=9+9)
LoadOrStoreLazyExistSingle-16   38.3ns ±11%  10.6ns ± 0%  -72.43%  (p=0.000 n=10+10)
LoadOrStoreRandom-16             209ns ±14%   206ns ±14%     ~     (p=0.684 n=10+10)
LoadOrStoreLazyRandom-16         215ns ± 8%   207ns ± 9%     ~     (p=0.139 n=10+10)
LoadOrStoreRandomSingle-16      1.05µs ± 1%  1.04µs ± 4%     ~     (p=0.535 n=9+10)
LoadOrStoreLazyRandomSingle-16  1.07µs ± 1%  1.06µs ± 3%   -1.09%  (p=0.029 n=8+9)
```