### PR TITLE
perf: improve SaveMetaInfoToMap performance

### DIFF
--- a/cloud/metainfo/info.go
+++ b/cloud/metainfo/info.go
@@ -80,22 +80,7 @@ func RangeValues(ctx context.Context, f func(k, v string) bool) {
 	if n == nil {
 		return
 	}
-
-	if cnt := len(n.stale) + len(n.transient); cnt == 0 {
-		return
-	}
-
-	for _, kv := range n.stale {
-		if !f(kv.key, kv.val) {
-			return
-		}
-	}
-
-	for _, kv := range n.transient {
-		if !f(kv.key, kv.val) {
-			return
-		}
-	}
+	rangeNode(n, f)
 }
 
 // WithValue sets the value into the context by the given key.
@@ -163,12 +148,7 @@ func RangePersistentValues(ctx context.Context, f func(k, v string) bool) {
 	if n == nil {
 		return
 	}
-
-	for _, kv := range n.persistent {
-		if !f(kv.key, kv.val) {
-			break
-		}
-	}
+	rangePersistentNode(n, f)
 }
 
 // WithPersistentValue sets the value info the context by the given key.
@@ -201,4 +181,28 @@ func DelPersistentValue(ctx context.Context, k string) context.Context {
 		}
 	}
 	return ctx
+}
+
+func rangeNode(n *node, f func(k, v string) bool) {
+	if cnt := len(n.stale) + len(n.transient); cnt == 0 {
+		return
+	}
+	for _, kv := range n.stale {
+		if !f(kv.key, kv.val) {
+			return
+		}
+	}
+	for _, kv := range n.transient {
+		if !f(kv.key, kv.val) {
+			return
+		}
+	}
+}
+
+func rangePersistentNode(n *node, f func(k, v string) bool) {
+	for _, kv := range n.persistent {
+		if !f(kv.key, kv.val) {
+			return
+		}
+	}
 }

--- a/cloud/metainfo/utils.go
+++ b/cloud/metainfo/utils.go
@@ -77,13 +77,19 @@ func SaveMetaInfoToMap(ctx context.Context, m map[string]string) {
 	if ctx == nil || m == nil {
 		return
 	}
-	ctx = TransferForward(ctx)
-	for k, v := range GetAllValues(ctx) {
+	n := getNode(ctx)
+	if n == nil {
+		return
+	}
+	n = n.transferForward()
+	rangeNode(n, func(k, v string) bool {
 		m[PrefixTransient+k] = v
-	}
-	for k, v := range GetAllPersistentValues(ctx) {
+		return true
+	})
+	rangePersistentNode(n, func(k, v string) bool {
 		m[PrefixPersistent+k] = v
-	}
+		return true
+	})
 }
 
 // sliceToMap converts a kv slice to map. If the slice is empty, an empty map will be returned instead of nil.


### PR DESCRIPTION
## Benchmark
**Before**:
```
BenchmarkAllParallel/SaveMetaInfoToMap_10
BenchmarkAllParallel/SaveMetaInfoToMap_10-12         	  912304	      1723 ns/op	    3720 B/op	      28 allocs/op
BenchmarkAllParallel/SaveMetaInfoToMap_20
BenchmarkAllParallel/SaveMetaInfoToMap_20-12         	  530864	      2380 ns/op	    8026 B/op	      50 allocs/op
BenchmarkAllParallel/SaveMetaInfoToMap_50
BenchmarkAllParallel/SaveMetaInfoToMap_50-12         	  205908	      5524 ns/op	   18170 B/op	     118 allocs/op
BenchmarkAllParallel/SaveMetaInfoToMap_100
BenchmarkAllParallel/SaveMetaInfoToMap_100-12        	   87831	     14197 ns/op	   36655 B/op	     226 allocs/op
```

**After**:
```
BenchmarkAllParallel/SaveMetaInfoToMap_10
BenchmarkAllParallel/SaveMetaInfoToMap_10-12         	 1258407	       897.6 ns/op	    2331 B/op	      22 allocs/op
BenchmarkAllParallel/SaveMetaInfoToMap_20
BenchmarkAllParallel/SaveMetaInfoToMap_20-12         	  639684	      1971 ns/op	    5404 B/op	      44 allocs/op
BenchmarkAllParallel/SaveMetaInfoToMap_50
BenchmarkAllParallel/SaveMetaInfoToMap_50-12         	  273380	      4734 ns/op	   12570 B/op	     109 allocs/op
BenchmarkAllParallel/SaveMetaInfoToMap_100
BenchmarkAllParallel/SaveMetaInfoToMap_100-12        	   98899	     11902 ns/op	   25629 B/op	     214 allocs/op
```