### PR TITLE
feat: add `GetBackwardValueToSend` api to get a single backward value to send from the given context

### DIFF
--- a/cloud/metainfo/backward.go
+++ b/cloud/metainfo/backward.go
@@ -181,6 +181,15 @@ func SendBackwardValuesFromMap(ctx context.Context, kvs map[string]string) (ok b
 	return
 }
 
+// GetBackwardValueToSend gets a value associated with the given key that is set by
+// `SendBackwardValue`, `SendBackwardValues` or `SendBackwardValuesFromMap`.
+func GetBackwardValueToSend(ctx context.Context, key string) (val string, ok bool) {
+	if p, exist := ctx.Value(bwCtxKeySend).(*bwCtxValue); exist {
+		val, ok = p.get(key)
+	}
+	return
+}
+
 // AllBackwardValuesToSend retrieves all key-values pairs set by `SendBackwardValue`
 // or `SendBackwardValues` from the given context.
 // This function is designed for frameworks, common developers should not use it.

--- a/cloud/metainfo/backward_test.go
+++ b/cloud/metainfo/backward_test.go
@@ -152,6 +152,10 @@ func TestWithBackwardValues5(t *testing.T) {
 	ok = metainfo.SendBackwardValues(ctx3, "key", "send2", "key1")
 	assert(t, !ok)
 
+	val, ok = metainfo.GetBackwardValueToSend(ctx3, "key")
+	assert(t, ok)
+	assert(t, val == "send0")
+
 	m = metainfo.RecvAllBackwardValues(ctx3)
 	assert(t, len(m) == 2)
 	assert(t, m["key"] == "recv0" && m["key1"] == "recv1", m)


### PR DESCRIPTION
en:
feat: add `GetBackwardValueToSend` api to get a single backward value to send from the given context.
zh:
feat: 增加 `GetBackwardValueToSend` api 用来从给定的context获取单一的待发送的反向传递值.