### PR TITLE
perf(metainfo): avoid temp maps to optimize SaveMetaInfoToMap

### DIFF
--- a/cloud/metainfo/utils.go
+++ b/cloud/metainfo/utils.go
@@ -78,11 +78,16 @@ func SaveMetaInfoToMap(ctx context.Context, m map[string]string) {
 		return
 	}
 	ctx = TransferForward(ctx)
-	for k, v := range GetAllValues(ctx) {
-		m[PrefixTransient+k] = v
-	}
-	for k, v := range GetAllPersistentValues(ctx) {
-		m[PrefixPersistent+k] = v
+	if n := getNode(ctx); n != nil {
+		for _, kv := range n.stale {
+			m[PrefixTransient+kv.key] = kv.val
+		}
+		for _, kv := range n.transient {
+			m[PrefixTransient+kv.key] = kv.val
+		}
+		for _, kv := range n.persistent {
+			m[PrefixPersistent+kv.key] = kv.val
+		}
 	}
 }
 


### PR DESCRIPTION

```
name                                  old time/op    new time/op    delta
All/SaveMetaInfoToMap_10-12             3.50µs ± 0%    2.18µs ± 0%  -37.77%  (p=1.000 n=1+1)
All/SaveMetaInfoToMap_20-12             7.04µs ± 0%    4.59µs ± 0%  -34.78%  (p=1.000 n=1+1)
All/SaveMetaInfoToMap_50-12             16.5µs ± 0%    10.8µs ± 0%  -34.37%  (p=1.000 n=1+1)
All/SaveMetaInfoToMap_100-12            35.5µs ± 0%    24.0µs ± 0%  -32.50%  (p=1.000 n=1+1)
AllParallel/SaveMetaInfoToMap_10-12     1.23µs ± 0%    0.75µs ± 0%  -39.33%  (p=1.000 n=1+1)
AllParallel/SaveMetaInfoToMap_20-12     2.42µs ± 0%    1.68µs ± 0%  -30.62%  (p=1.000 n=1+1)
AllParallel/SaveMetaInfoToMap_50-12     5.64µs ± 0%    3.96µs ± 0%  -29.77%  (p=1.000 n=1+1)
AllParallel/SaveMetaInfoToMap_100-12    15.2µs ± 0%    10.3µs ± 0%  -31.87%  (p=1.000 n=1+1)

name                                  old alloc/op   new alloc/op   delta
All/SaveMetaInfoToMap_10-12             3.72kB ± 0%    2.46kB ± 0%  -33.87%  (p=1.000 n=1+1)
All/SaveMetaInfoToMap_20-12             8.03kB ± 0%    5.53kB ± 0%  -31.08%  (p=1.000 n=1+1)
All/SaveMetaInfoToMap_50-12             18.2kB ± 0%    12.7kB ± 0%  -30.10%  (p=1.000 n=1+1)
All/SaveMetaInfoToMap_100-12            36.7kB ± 0%    25.8kB ± 0%  -29.73%  (p=1.000 n=1+1)
AllParallel/SaveMetaInfoToMap_10-12     3.72kB ± 0%    2.46kB ± 0%  -33.87%  (p=1.000 n=1+1)
AllParallel/SaveMetaInfoToMap_20-12     8.03kB ± 0%    5.53kB ± 0%  -31.07%  (p=1.000 n=1+1)
AllParallel/SaveMetaInfoToMap_50-12     18.2kB ± 0%    12.7kB ± 0%  -30.11%  (p=1.000 n=1+1)
AllParallel/SaveMetaInfoToMap_100-12    36.7kB ± 0%    25.8kB ± 0%  -29.72%  (p=1.000 n=1+1)

name                                  old allocs/op  new allocs/op  delta
All/SaveMetaInfoToMap_10-12               28.0 ± 0%      24.0 ± 0%  -14.29%  (p=1.000 n=1+1)
All/SaveMetaInfoToMap_20-12               50.0 ± 0%      46.0 ± 0%   -8.00%  (p=1.000 n=1+1)
All/SaveMetaInfoToMap_50-12                117 ± 0%       111 ± 0%   -5.13%  (p=1.000 n=1+1)
All/SaveMetaInfoToMap_100-12               226 ± 0%       216 ± 0%   -4.42%  (p=1.000 n=1+1)
AllParallel/SaveMetaInfoToMap_10-12       28.0 ± 0%      24.0 ± 0%  -14.29%  (p=1.000 n=1+1)
AllParallel/SaveMetaInfoToMap_20-12       50.0 ± 0%      46.0 ± 0%   -8.00%  (p=1.000 n=1+1)
AllParallel/SaveMetaInfoToMap_50-12        118 ± 0%       111 ± 0%   -5.93%  (p=1.000 n=1+1)
AllParallel/SaveMetaInfoToMap_100-12       226 ± 0%       216 ± 0%   -4.42%  (p=1.000 n=1+1)
```