### PR TITLE
optimize: dont reuse goroutine if it panicked

### DIFF
--- a/util/gopool/worker.go
+++ b/util/gopool/worker.go
@@ -40,8 +40,10 @@ func newWorker() interface{} {
 func (w *worker) run() {
 	go func() {
 		for {
-			var t *task
-			var panicked bool
+			var (
+				t        *task
+				panicked bool
+			)
 			w.pool.taskLock.Lock()
 			if w.pool.taskHead != nil {
 				t = w.pool.taskHead
@@ -49,7 +51,7 @@ func (w *worker) run() {
 				atomic.AddInt32(&w.pool.taskCount, -1)
 			}
 			if t == nil {
-				// if there's no task to do, exit
+				// If there's no task to do, exit
 				w.close()
 				w.pool.taskLock.Unlock()
 				w.Recycle()
@@ -70,8 +72,8 @@ func (w *worker) run() {
 				}()
 				t.f()
 			}()
-			// if task function panicked, don't reuse the goroutine
-			// because the current goroutine may be already attached wrong states(like pprof labels).
+			// If the task function panicked, don't reuse the goroutine.
+			// Because the current goroutine may be already attached wrong states(like pprof labels).
 			if panicked {
 				return
 			}

--- a/util/gopool/worker.go
+++ b/util/gopool/worker.go
@@ -72,12 +72,14 @@ func (w *worker) run() {
 				}()
 				t.f()
 			}()
+			t.Recycle()
 			// If the task function panicked, don't reuse the goroutine.
 			// Because the current goroutine may be already attached wrong states(like pprof labels).
 			if panicked {
+				w.close()
+				w.Recycle()
 				return
 			}
-			t.Recycle()
 		}
 	}()
 }


### PR DESCRIPTION
panic 会影响 goroutine 的执行流，而golang支持对goroutine添加一些G state ，比如 pprof labels。还有一些其他hack的库，甚至会拿goroutine id做一些事情。如果状态没有清理干净，goroutine 被重用会有一定污染风险。

所以处于安全考虑，在 panic 的时候就不再重用当前 goroutine。