### PR TITLE
optimise(gopool): no cap by default

### DIFF
--- a/util/gopool/gopool.go
+++ b/util/gopool/gopool.go
@@ -17,6 +17,7 @@ package gopool
 import (
 	"context"
 	"fmt"
+	"math"
 	"sync"
 )
 
@@ -26,7 +27,7 @@ var defaultPool Pool
 var poolMap sync.Map
 
 func init() {
-	defaultPool = NewPool("gopool.DefaultPool", 10000, NewConfig())
+	defaultPool = NewPool("gopool.DefaultPool", math.MaxInt32, NewConfig())
 }
 
 // Go is an alternative to the go keyword, which is able to recover panic.


### PR DESCRIPTION
gopool 并不要求每个 goroutine 都不能阻塞，如果运行过程中，所有阻塞型task超过 10000 ，就会彻底停止响应。这个危害要大于单纯就是创建更过goroutine，所以默认将 cap 设置为最大。

如果能精确确定每个 task 都是非阻塞型task，并且需要控制最大 goroutine 数量。可以自行 New 一个特殊定制的 pool。

PS：考虑过用 cap 为 0 代表无限制，但是这样的运行时 CAS 操作其实会更多一次，所以简单用 MaxInt32 代替。