### PR TITLE
perf: metainfo reduce mallocgc

### DIFF
--- a/cloud/metainfo/http_test.go
+++ b/cloud/metainfo/http_test.go
@@ -87,7 +87,7 @@ func TestFromHTTPHeaderKeepPreviousData(t *testing.T) {
 	c1 := metainfo.FromHTTPHeader(c0, metainfo.HTTPHeader(h))
 	assert(t, c0 != c1)
 	vs := metainfo.GetAllValues(c1)
-	assert(t, len(vs) == 3)
+	assert(t, len(vs) == 3, len(vs))
 	assert(t, vs["tk"] == "tv" && vs["uk"] == "uv" && vs["XK"] == "xv")
 	vs = metainfo.GetAllPersistentValues(c1)
 	assert(t, len(vs) == 3)

--- a/cloud/metainfo/kv.go
+++ b/cloud/metainfo/kv.go
@@ -14,7 +14,9 @@
 
 package metainfo
 
-import "context"
+import (
+	"context"
+)
 
 type ctxKeyType struct{}
 
@@ -120,40 +122,6 @@ func (n *node) delPersistent(k string) (r *node) {
 		}
 	}
 	return n
-}
-
-type mapView struct {
-	persistent map[string]string
-	transient  map[string]string
-	stale      map[string]string
-}
-
-func newMapView() *mapView {
-	return &mapView{
-		persistent: make(map[string]string),
-		transient:  make(map[string]string),
-		stale:      make(map[string]string),
-	}
-}
-
-func (m *mapView) size() int {
-	return len(m.persistent) + len(m.transient) + len(m.stale)
-}
-
-func (m *mapView) toNode() *node {
-	return &node{
-		persistent: mapToSlice(m.persistent),
-		transient:  mapToSlice(m.transient),
-		stale:      mapToSlice(m.stale),
-	}
-}
-
-func (n *node) mapView() *mapView {
-	return &mapView{
-		persistent: sliceToMap(n.persistent),
-		transient:  sliceToMap(n.transient),
-		stale:      sliceToMap(n.stale),
-	}
 }
 
 func search(kvs []kv, key string) (idx int, ok bool) {

--- a/cloud/metainfo/kv.go
+++ b/cloud/metainfo/kv.go
@@ -27,6 +27,33 @@ type kv struct {
 	val string
 }
 
+func newNodeFromMaps(persistent, transient, stale kvstore) *node {
+	ps, ts, sz := persistent.size(), transient.size(), stale.size()
+	// make slices together to reduce malloc cost
+	kvs := make([]kv, ps+ts+sz)
+	nd := new(node)
+	nd.persistent = kvs[:ps]
+	nd.transient = kvs[ps : ps+ts]
+	nd.stale = kvs[ps+ts:]
+
+	i := 0
+	for k, v := range persistent {
+		nd.persistent[i].key, nd.persistent[i].val = k, v
+		i++
+	}
+	i = 0
+	for k, v := range transient {
+		nd.transient[i].key, nd.transient[i].val = k, v
+		i++
+	}
+	i = 0
+	for k, v := range stale {
+		nd.stale[i].key, nd.stale[i].val = k, v
+		i++
+	}
+	return nd
+}
+
 type node struct {
 	persistent []kv
 	transient  []kv

--- a/cloud/metainfo/kvstore.go
+++ b/cloud/metainfo/kvstore.go
@@ -1,0 +1,58 @@
+// Copyright 2023 ByteDance Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metainfo
+
+import "sync"
+
+type kvstore map[string]string
+
+var kvpool sync.Pool
+
+func newKVStore(size ...int) kvstore {
+	kvs := kvpool.Get()
+	if kvs == nil {
+		if len(size) > 0 {
+			return make(kvstore, size[0])
+		}
+		return make(kvstore)
+	}
+	return kvs.(kvstore)
+}
+
+func (store kvstore) toList(kvs []kv) []kv {
+	for k, v := range store {
+		kvs = append(kvs, kv{key: k, val: v})
+	}
+	return kvs
+}
+
+func (store kvstore) recycle() {
+	/*
+			for k := range m {
+				delete(m, k)
+			}
+		  ==>
+			LEAQ    type.map[string]int(SB), AX
+			MOVQ    AX, (SP)
+			MOVQ    "".m(SB), AX
+			MOVQ    AX, 8(SP)
+			PCDATA  $1, $0
+			CALL    runtime.mapclear(SB)
+	*/
+	for key := range store {
+		delete(store, key)
+	}
+	kvpool.Put(store)
+}

--- a/cloud/metainfo/kvstore.go
+++ b/cloud/metainfo/kvstore.go
@@ -31,11 +31,8 @@ func newKVStore(size ...int) kvstore {
 	return kvs.(kvstore)
 }
 
-func (store kvstore) toList(kvs []kv) []kv {
-	for k, v := range store {
-		kvs = append(kvs, kv{key: k, val: v})
-	}
-	return kvs
+func (store kvstore) size() int {
+	return len(store)
 }
 
 func (store kvstore) recycle() {

--- a/cloud/metainfo/kvstore_test.go
+++ b/cloud/metainfo/kvstore_test.go
@@ -1,0 +1,66 @@
+// Copyright 2023 ByteDance Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metainfo
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestKVStore(t *testing.T) {
+	store := newKVStore()
+	store["a"] = "a"
+	store["a"] = "b"
+	if store["a"] != "b" {
+		t.Fatal()
+	}
+	store.recycle()
+	if store["a"] == "b" {
+		t.Fatal()
+	}
+	store = newKVStore()
+	if store["a"] == "b" {
+		t.Fatal()
+	}
+}
+
+func BenchmarkMap(b *testing.B) {
+	for keys := 1; keys <= 1000; keys *= 10 {
+		b.Run(fmt.Sprintf("keys=%d", keys), func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				m := make(map[string]string)
+				for idx := 0; idx < 1000; idx++ {
+					m[fmt.Sprintf("key-%d", idx)] = string('a' + byte(idx%26))
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkKVStore(b *testing.B) {
+	for keys := 1; keys <= 1000; keys *= 10 {
+		b.Run(fmt.Sprintf("keys=%d", keys), func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				m := newKVStore()
+				for idx := 0; idx < 1000; idx++ {
+					m[fmt.Sprintf("key-%d", idx)] = string('a' + byte(idx%26))
+				}
+				m.recycle()
+			}
+		})
+	}
+}

--- a/cloud/metainfo/utils.go
+++ b/cloud/metainfo/utils.go
@@ -112,14 +112,14 @@ func SaveMetaInfoToMap(ctx context.Context, m map[string]string) {
 	}
 	ctx = TransferForward(ctx)
 	if n := getNode(ctx); n != nil {
-		for _, kv := range n.persistent {
-			m[PrefixPersistent+kv.key] = kv.val
+		for _, kv := range n.stale {
+			m[PrefixTransient+kv.key] = kv.val
 		}
 		for _, kv := range n.transient {
 			m[PrefixTransient+kv.key] = kv.val
 		}
-		for _, kv := range n.stale {
-			m[PrefixTransient+kv.key] = kv.val
+		for _, kv := range n.persistent {
+			m[PrefixPersistent+kv.key] = kv.val
 		}
 	}
 }

--- a/cloud/metainfo/utils_test.go
+++ b/cloud/metainfo/utils_test.go
@@ -16,6 +16,7 @@ package metainfo_test
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/bytedance/gopkg/cloud/metainfo"
@@ -145,4 +146,17 @@ func TestSaveMetaInfoToMap(t *testing.T) {
 	assert(t, len(m) == 2)
 	assert(t, m[metainfo.PrefixTransient+"b"] == "b2")
 	assert(t, m[metainfo.PrefixPersistent+"b"] == "b3")
+}
+
+func BenchmarkSetMetaInfoFromMap(b *testing.B) {
+	ctx := metainfo.WithPersistentValue(context.Background(), "key", "val")
+	m := map[string]string{}
+	for i := 0; i < 32; i++ {
+		m[fmt.Sprintf("key-%d", i)] = fmt.Sprintf("val-%d", i)
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = metainfo.SetMetaInfoFromMap(ctx, m)
+	}
 }


### PR DESCRIPTION
### Summary

- FromHTTPHeader: reduce 18%~46%
- SaveMetaInfoToMap: reduced 37%~40%
- SetMetaInfoFromMap: reduced 60%~66%

### Benchmark

Before:
```
BenchmarkFromHTTPHeader/FromHTTPHeader-10-4         	  533098	      2219 ns/op	    1177 B/op	      19 allocs/op
BenchmarkFromHTTPHeader/FromHTTPHeader-20-4         	  239277	      5008 ns/op	    2683 B/op	      31 allocs/op
BenchmarkAll/SaveMetaInfoToMap_10-4                 	  235621	      4867 ns/op	    3880 B/op	      28 allocs/op
BenchmarkAll/SaveMetaInfoToMap_20-4                 	  121765	     10373 ns/op	    8345 B/op	      50 allocs/op
BenchmarkAll/SaveMetaInfoToMap_50-4                 	   50384	     23848 ns/op	   18977 B/op	     118 allocs/op
BenchmarkAll/SaveMetaInfoToMap_100-4                	   23650	     50333 ns/op	   38275 B/op	     226 allocs/op
BenchmarkAll/SetMetaInfoFromMap_10-4                	  377126	      3019 ns/op	    1932 B/op	       6 allocs/op
BenchmarkAll/SetMetaInfoFromMap_20-4                	  178387	      6894 ns/op	    5111 B/op	       8 allocs/op
BenchmarkAll/SetMetaInfoFromMap_50-4                	   76599	     16080 ns/op	   13111 B/op	      14 allocs/op
BenchmarkAll/SetMetaInfoFromMap_100-4               	   38401	     31900 ns/op	   26885 B/op	      22 allocs/op
```

After: 
```
BenchmarkFromHTTPHeader/FromHTTPHeader-10-4         	  723223	      1659 ns/op	    1737 B/op	      14 allocs/op
BenchmarkFromHTTPHeader/FromHTTPHeader-20-4         	  440990	      2764 ns/op	    1769 B/op	      24 allocs/op
BenchmarkAll/SaveMetaInfoToMap_10-4                 	  369705	      3007 ns/op	    2619 B/op	      24 allocs/op
BenchmarkAll/SaveMetaInfoToMap_20-4                 	  188844	      6331 ns/op	    5851 B/op	      46 allocs/op
BenchmarkAll/SaveMetaInfoToMap_50-4                 	   80311	     14951 ns/op	   13504 B/op	     111 allocs/op
BenchmarkAll/SaveMetaInfoToMap_100-4                	   39208	     30654 ns/op	   27362 B/op	     216 allocs/op
BenchmarkAll/SetMetaInfoFromMap_10-4                	  934087	      1296 ns/op	    2048 B/op	       5 allocs/op
BenchmarkAll/SetMetaInfoFromMap_20-4                	  529394	      2293 ns/op	    3968 B/op	       5 allocs/op
BenchmarkAll/SetMetaInfoFromMap_50-4                	  237283	      5076 ns/op	    9728 B/op	       5 allocs/op
BenchmarkAll/SetMetaInfoFromMap_100-4               	  128302	      9549 ns/op	   19712 B/op	       5 allocs/op
```