### PR TITLE
ci: disable push-check in forks

### DIFF
--- a/.github/workflows/push-check.yml
+++ b/.github/workflows/push-check.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   build:
     runs-on: self-hosted
+    if: github.repository == 'bytedance/gopkg'
     steps:
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
Since `bytedance/gopkg` uses self-hosted runner, push-check should be disabled in forks.