### PR TITLE
fix: change runtime.fastrand to runtime.cheaprand in go 1.22

### DIFF
--- a/internal/runtimex/runtime_go_1.22.go
+++ b/internal/runtimex/runtime_go_1.22.go
@@ -1,4 +1,4 @@
-// Copyright 2021 ByteDance Inc.
+// Copyright 2024 ByteDance Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/runtimex/runtime_go_1.22.go
+++ b/internal/runtimex/runtime_go_1.22.go
@@ -1,0 +1,25 @@
+// Copyright 2021 ByteDance Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build go1.22
+// +build go1.22
+
+package runtimex
+
+import (
+	_ "unsafe" // for linkname
+)
+
+//go:linkname Fastrand runtime.cheaprand
+func Fastrand() uint32

--- a/internal/runtimex/runtime_pre_go_1.22.go
+++ b/internal/runtimex/runtime_pre_go_1.22.go
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build !go1.22
+// +build !go1.22
+
 package runtimex
 
 import (

--- a/internal/runtimex/runtime_test.go
+++ b/internal/runtimex/runtime_test.go
@@ -1,0 +1,9 @@
+package runtimex
+
+import "testing"
+
+func BenchmarkFastrand(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		Fastrand()
+	}
+}

--- a/internal/runtimex/runtime_test.go
+++ b/internal/runtimex/runtime_test.go
@@ -1,6 +1,35 @@
+// Copyright 2024 ByteDance Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package runtimex
 
 import "testing"
+
+func TestFastrand(t *testing.T) {
+	var isRandom bool
+	for i := 0; i < 3; i++ {
+		x := Fastrand()
+		y := Fastrand()
+		if x != y {
+			isRandom = true
+			break
+		}
+	}
+	if !isRandom {
+		t.Fatal("Invalid fastrand results")
+	}
+}
 
 func BenchmarkFastrand(b *testing.B) {
 	for i := 0; i < b.N; i++ {


### PR DESCRIPTION
在 Go 1.22 中 `runtime.fastrand` 被重构，原先的版本被改为 `runtime.cheaprand`

但经过测试还是原先的版本更快，而且差距很大

<img width="1680" alt="image" src="https://github.com/bytedance/gopkg/assets/58617692/a87babe1-9257-49fc-986c-b9cd8a68d523">

所以我建议在 go 版本大于等于 1.22 时，使用  `runtime.cheaprand` 而不是  `runtime.fastrand` 

ref: https://zhuanlan.zhihu.com/p/673906980

ps: 本人在复盘 Kitex  的 Alias Method 算法 （ https://github.com/cloudwego/kitex/pull/1199 ）时发现在 Go 1.22 版本下的性能倒退现象，追查到本项目的 fastrand ，而 fastrand 直接依赖于  `runtime.fastrand` 