### PR TITLE
feat: Promise/Future for multi-consumer async acquiring result

### DIFF
--- a/lang/syncx/README.md
+++ b/lang/syncx/README.md
@@ -43,3 +43,30 @@ func getput() {
 ```
 
 ## 2. syncx.RWMutex
+
+## 3. syncx.Promise
+
+The `syncx.Promise` provides a facility to store a value or an error that is later acquired asynchronously via a `syncx.Future` created by the `syncx.Promise` object. Note that the `syncx.Promise` object is meant to be used only once.
+
+### Example
+
+```go
+package main
+
+import "github.com/bytedance/gopkg/lang/syncx"
+
+func Supplier() *syncx.Promise {
+    p := syncx.NewPromise()
+	go func() {
+		p.Set("foo", nil)
+    }()
+	return p
+}
+
+func main() {
+   p := Supplier()
+   f := p.Future()
+   val, err := f.Get()
+   println(val, err)
+}
+```

--- a/lang/syncx/README.md
+++ b/lang/syncx/README.md
@@ -55,18 +55,18 @@ package main
 
 import "github.com/bytedance/gopkg/lang/syncx"
 
-func Supplier() *syncx.Promise {
-    p := syncx.NewPromise()
+func foo() *syncx.Promise {
+	p := syncx.NewPromise()
 	go func() {
 		p.Set("foo", nil)
-    }()
+	}()
 	return p
 }
 
 func main() {
-   p := Supplier()
-   f := p.Future()
-   val, err := f.Get()
-   println(val, err)
+	p := foo()
+	f := p.Future()
+	val, err := f.Get()
+	println(val, err)
 }
 ```

--- a/lang/syncx/future.go
+++ b/lang/syncx/future.go
@@ -1,3 +1,17 @@
+// Copyright 2024 ByteDance Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package syncx
 
 import (

--- a/lang/syncx/future.go
+++ b/lang/syncx/future.go
@@ -1,0 +1,70 @@
+package syncx
+
+import (
+	"sync"
+	"sync/atomic"
+)
+
+type state struct {
+	noCopy noCopy
+
+	m    sync.Mutex
+	c    *sync.Cond
+	done int32
+	val  interface{}
+	err  error
+}
+
+type Promise struct {
+	state *state
+}
+
+type Future struct {
+	state *state
+}
+
+func newState() *state {
+	s := &state{}
+	s.c = sync.NewCond(&s.m)
+	return s
+}
+
+func (s *state) set(val interface{}, err error) {
+	s.m.Lock()
+	defer s.m.Unlock()
+	if atomic.LoadInt32(&s.done) == 1 {
+		panic("promise already satisfied")
+	}
+	s.val = val
+	s.err = err
+	atomic.StoreInt32(&s.done, 1)
+	s.c.Broadcast()
+}
+
+func (s *state) get() (interface{}, error) {
+	if atomic.LoadInt32(&s.done) == 1 {
+		return s.val, s.err
+	}
+	s.m.Lock()
+	defer s.m.Unlock()
+	for atomic.LoadInt32(&s.done) != 1 {
+		s.c.Wait()
+	}
+	return s.val, s.err
+}
+
+func NewPromise() *Promise {
+	return &Promise{state: newState()}
+}
+
+func (p *Promise) Set(val interface{}, err error) {
+	p.state.set(val, err)
+}
+
+func (p *Promise) Future() *Future {
+	return &Future{state: p.state}
+}
+
+func (f *Future) Get() (interface{}, error) {
+	return f.state.get()
+}

--- a/lang/syncx/future_test.go
+++ b/lang/syncx/future_test.go
@@ -1,3 +1,17 @@
+// Copyright 2024 ByteDance Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package syncx
 
 import (

--- a/lang/syncx/future_test.go
+++ b/lang/syncx/future_test.go
@@ -1,0 +1,58 @@
+package syncx
+
+import (
+	"errors"
+	"runtime"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var errFoo = errors.New("foo")
+
+func TestPromiseAndFuture(t *testing.T) {
+	p := NewPromise()
+	f := p.Future()
+	p.Set(1, errFoo)
+	val, err := f.Get()
+	assert.Equal(t, val, 1)
+	assert.Equal(t, err, errFoo)
+}
+
+func TestPromiseAndFutureConcurrency(t *testing.T) {
+	n := runtime.NumCPU() - 1
+
+	ch := make(chan struct{}, n)
+	p := NewPromise()
+	go func() {
+		for i := 0; i < n; i++ {
+			ch <- struct{}{}
+		}
+		time.Sleep(1 * time.Second)
+		p.Set(1, errFoo)
+	}()
+
+	wg := sync.WaitGroup{}
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-ch
+			f := p.Future()
+			val, err := f.Get()
+			assert.Equal(t, val, 1)
+			assert.Equal(t, err, errFoo)
+		}()
+	}
+	wg.Wait()
+}
+
+func TestPromiseSetTwice(t *testing.T) {
+	p := NewPromise()
+	p.Set(1, nil)
+	assert.Panics(t, func() {
+		p.Set(1, nil)
+	})
+}

--- a/lang/syncx/linkname.go
+++ b/lang/syncx/linkname.go
@@ -29,3 +29,11 @@ func runtime_registerPoolCleanup(cleanup func())
 //go:noescape
 //go:linkname runtime_poolCleanup sync.poolCleanup
 func runtime_poolCleanup()
+
+//go:noescape
+//go:linkname runtime_Semacquire sync.runtime_Semacquire
+func runtime_Semacquire(s *uint32)
+
+//go:noescape
+//go:linkname runtime_Semrelease sync.runtime_Semrelease
+func runtime_Semrelease(s *uint32, handoff bool, skipframes int)


### PR DESCRIPTION
The `syncx.Promise` provides a facility to store a value or an error that is later acquired asynchronously via a `syncx.Future` created by the `syncx.Promise` object. Note that the `syncx.Promise` object is meant to be used only once.

As same as `std::promise` and `std::future` in C++(https://en.cppreference.com/w/cpp/thread/promise)