### PR TITLE
fix: close consume chan when close in throttle waiting

### DIFF
--- a/lang/channel/channel.go
+++ b/lang/channel/channel.go
@@ -283,6 +283,8 @@ func (c *channel) consume() {
 		// check throttle
 		if c.throttling(c.consumerThrottle) {
 			// closed
+			close(c.consumer)               // close consumer
+			atomic.StoreInt32(&c.state, -2) // -2 means closed totally
 			return
 		}
 


### PR DESCRIPTION
### Reproduction condition 
1. channel using **consume throttle**: eg `ch := channel.New(channel.WithRateThrottle(0, 1))`
2. have a goroutine block on `ch.Output()`
3. and then call ch.Close() in another goroutine

In such case, ch.Output() will not be triggered and this goroutine will be leak and block forever.

The root cause is when consume throttle recover, it forget to close channel and let output channel alive.