### PR TITLE
ci: seperate license check & remove unused config

### DIFF
--- a/.github/workflows/push-check.yml
+++ b/.github/workflows/push-check.yml
@@ -19,22 +19,20 @@ jobs:
         with:
           go-version: 1.18
 
-      - uses: actions/cache@v4
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
-
-      - name: Check License Header
-        uses: apache/skywalking-eyes/header@v0.4.0
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Lint
         run: |
           test -z "$(gofmt -s -l .)"
           go vet -stdmethods=false $(go list ./...)
 
       - name: Unit Test
-        run: go test -v -race -covermode=atomic -coverprofile=coverage.out ./...
+        run: go test -race ./...
+
+  license-header-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check License Header
+        uses: apache/skywalking-eyes/header@v0.4.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
* faster ci workflow for seperating license check
* actions/cache is duplicated with setup-go
* go test coverage is unnecessary coz we're not using codecov