### PR TITLE
feat(circuitbreaker): cleanup breakers with no samples to prevent memory leak

### DIFF
--- a/cloud/circuitbreaker/panel.go
+++ b/cloud/circuitbreaker/panel.go
@@ -178,9 +178,13 @@ func (t *sharedTicker) tick(ticker *time.Ticker) {
 		case <-ticker.C:
 			t.Lock()
 			for p := range t.panels {
-				p.breakers.Range(func(_ string, value interface{}) bool {
+				p.breakers.Range(func(key string, value interface{}) bool {
 					if b, ok := value.(*breaker); ok {
 						b.metricer.tick()
+						// If the breaker has no samples, remove it
+						if b.Metricer().Samples() == 0 {
+							p.RemoveBreaker(key)
+						}
 					}
 					return true
 				})

--- a/cloud/circuitbreaker/per_p_metricer_test.go
+++ b/cloud/circuitbreaker/per_p_metricer_test.go
@@ -103,6 +103,10 @@ func TestPerPMetricer2(t *testing.T) {
 	deepEqual(t, m.Failures(), int64(0))
 	deepEqual(t, m.Timeouts(), int64(0))
 
+	// Re-fetch breaker since it may have been removed after samples became 0
+	b = p.(*panel).getBreaker("test")
+	m = b.metricer
+
 	for i := 0; i < 10; i++ {
 		m.Fail()
 	}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Removes idle circuit breakers when their metrics window has zero samples and updates tests accordingly.
> 
> - In `sharedTicker.tick`, after `metricer.tick()`, remove breaker via `RemoveBreaker(key)` when `b.Metricer().Samples() == 0` (adjusts `Range` callback to capture `key`)
> - `TestPerPMetricer2`: re-fetches the breaker after expiration since it may have been removed
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 25d1017695fe7b2ce9256b26e3a2b7f6029961b0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->