### PR TITLE
feat: metainfo supports WithoutPersistentValues

### DIFF
--- a/cloud/metainfo/info.go
+++ b/cloud/metainfo/info.go
@@ -225,6 +225,20 @@ func DelPersistentValue(ctx context.Context, k string) context.Context {
 	return ctx
 }
 
+// WithoutPersistentValues creates a new ctx without all persistent key/values from the current context, transient values are not affected.
+func WithoutPersistentValues(ctx context.Context) context.Context {
+	if n := getNode(ctx); n != nil {
+		if len(n.persistent) == 0 {
+			return ctx
+		}
+		return withNode(ctx, &node{
+			transient: n.transient,
+			stale:     n.stale,
+		})
+	}
+	return ctx
+}
+
 func getKey(kvs []string, i int) string {
 	return kvs[i*2]
 }

--- a/cloud/metainfo/info_test.go
+++ b/cloud/metainfo/info_test.go
@@ -927,3 +927,54 @@ func TestGetValueToMap(t *testing.T) {
 	metainfo.GetValueToMap(ctx, m, k)
 	assert(t, m[k] == v)
 }
+
+func TestWithoutPersistentValues(t *testing.T) {
+	// Normal behaviour
+	ctx := context.Background()
+
+	k1, v1 := "key1", "value1"
+	k2, v2 := "key2", "value2"
+	k3, v3 := "key3", "value3"
+	ctx = metainfo.WithPersistentValue(ctx, k1, v1)
+	ctx = metainfo.WithPersistentValue(ctx, k2, v2)
+	ctx = metainfo.WithPersistentValue(ctx, k3, v3)
+
+	ctx = metainfo.WithoutPersistentValues(ctx)
+	assert(t, ctx != nil)
+
+	_, ok := metainfo.GetPersistentValue(ctx, k1)
+	assert(t, !ok)
+	_, ok = metainfo.GetPersistentValue(ctx, k2)
+	assert(t, !ok)
+	_, ok = metainfo.GetPersistentValue(ctx, k3)
+	assert(t, !ok)
+
+	m := metainfo.GetAllPersistentValues(ctx)
+	assert(t, len(m) == 0)
+
+	// Transient values should remain
+	ctx = context.Background()
+	kt, vt := "transientKey", "transientValue"
+	kp, vp := "persistentKey", "persistentValue"
+	ctx = metainfo.WithValue(ctx, kt, vt)
+	ctx = metainfo.WithPersistentValue(ctx, kp, vp)
+
+	ctx = metainfo.WithoutPersistentValues(ctx)
+
+	x, ok := metainfo.GetValue(ctx, kt)
+	assert(t, ok)
+	assert(t, x == vt)
+	_, ok = metainfo.GetPersistentValue(ctx, kp)
+	assert(t, !ok)
+
+	// Context without node
+	ctx = context.Background()
+	newCtx := metainfo.WithoutPersistentValues(ctx)
+	assert(t, newCtx == ctx)
+
+	// No persistent values
+	ctx = context.Background()
+	ctx = metainfo.WithValue(ctx, "key", "val")
+	newCtx = metainfo.WithoutPersistentValues(ctx)
+	assert(t, newCtx == ctx)
+}


### PR DESCRIPTION
To remove all PersistentValues currently, we must first call ```GetAllPersistentValues```, then sequentially execute ```DelPersistentValue```.

However, each ```DelPersistentValue``` call creates a new copy of the persistent key-value pair.

If the ctx contains an excessive number of PersistentValues, this will result in the allocation of a large number of objects.