### PR TITLE
test(nomerge): add porcupine linearizability test

### DIFF
--- a/collection/skipmap/linearizability_test.go
+++ b/collection/skipmap/linearizability_test.go
@@ -1,0 +1,242 @@
+// Copyright 2021 ByteDance Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package skipmap
+
+import (
+	"fmt"
+	"math/rand"
+	"os"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/anishathalye/porcupine"
+)
+
+const (
+	opLoad = iota
+	opLoadOrStore
+	opStore
+	opLoadAndDelete
+	numOps
+)
+
+type skipmapInput struct {
+	Op    int
+	Key   string
+	Value int
+}
+
+type skipmapOutput struct {
+	Value int
+	Ok    bool
+}
+
+type perKeyState struct {
+	Exists bool
+	Value  int
+}
+
+var skipmapModel = porcupine.Model{
+	Init: func() interface{} { return perKeyState{} },
+	Step: func(state, input, output interface{}) (bool, interface{}) {
+		st := state.(perKeyState)
+		inp := input.(skipmapInput)
+		out := output.(skipmapOutput)
+
+		switch inp.Op {
+		case opLoad:
+			if st.Exists {
+				return out.Ok && out.Value == st.Value, st
+			}
+			return !out.Ok && out.Value == 0, st
+		case opLoadOrStore:
+			if st.Exists {
+				return out.Ok && out.Value == st.Value, st
+			}
+			if !out.Ok && out.Value == inp.Value {
+				return true, perKeyState{Exists: true, Value: inp.Value}
+			}
+			return false, st
+		case opStore:
+			return true, perKeyState{Exists: true, Value: inp.Value}
+		case opLoadAndDelete:
+			if st.Exists {
+				if out.Ok && out.Value == st.Value {
+					return true, perKeyState{}
+				}
+				return false, st
+			}
+			return !out.Ok && out.Value == 0, st
+		default:
+			return false, st
+		}
+	},
+	Equal: func(a, b interface{}) bool {
+		return a.(perKeyState) == b.(perKeyState)
+	},
+	DescribeOperation: func(input, output interface{}) string {
+		inp := input.(skipmapInput)
+		out := output.(skipmapOutput)
+		switch inp.Op {
+		case opLoad:
+			if out.Ok {
+				return fmt.Sprintf("Load(%s) -> %d", inp.Key, out.Value)
+			}
+			return fmt.Sprintf("Load(%s) -> nil", inp.Key)
+		case opLoadOrStore:
+			if out.Ok {
+				return fmt.Sprintf("LoadOrStore(%s, %d) -> loaded %d", inp.Key, inp.Value, out.Value)
+			}
+			return fmt.Sprintf("LoadOrStore(%s, %d) -> stored", inp.Key, inp.Value)
+		case opStore:
+			return fmt.Sprintf("Store(%s, %d)", inp.Key, inp.Value)
+		case opLoadAndDelete:
+			if out.Ok {
+				return fmt.Sprintf("LoadAndDelete(%s) -> %d", inp.Key, out.Value)
+			}
+			return fmt.Sprintf("LoadAndDelete(%s) -> nil", inp.Key)
+		default:
+			return "?"
+		}
+	},
+	DescribeState: func(state interface{}) string {
+		st := state.(perKeyState)
+		if st.Exists {
+			return fmt.Sprintf("value=%d", st.Value)
+		}
+		return "absent"
+	},
+}
+
+func executeSkipmapOp(m *StringMap, input skipmapInput) skipmapOutput {
+	switch input.Op {
+	case opLoad:
+		value, ok := m.Load(input.Key)
+		if ok {
+			return skipmapOutput{Value: value.(int), Ok: true}
+		}
+		return skipmapOutput{}
+	case opLoadOrStore:
+		actual, loaded := m.LoadOrStore(input.Key, input.Value)
+		return skipmapOutput{Value: actual.(int), Ok: loaded}
+	case opStore:
+		m.Store(input.Key, input.Value)
+		return skipmapOutput{}
+	case opLoadAndDelete:
+		value, loaded := m.LoadAndDelete(input.Key)
+		if loaded {
+			return skipmapOutput{Value: value.(int), Ok: true}
+		}
+		return skipmapOutput{}
+	default:
+		return skipmapOutput{}
+	}
+}
+
+func checkPerKeyLinearizability(operations []porcupine.Operation, timeout time.Duration) (bool, []porcupine.LinearizationInfo) {
+	byKey := make(map[string][]porcupine.Operation)
+	for _, op := range operations {
+		byKey[op.Input.(skipmapInput).Key] = append(byKey[op.Input.(skipmapInput).Key], op)
+	}
+
+	var mu sync.Mutex
+	var failures []porcupine.LinearizationInfo
+	var wg sync.WaitGroup
+
+	for _, ops := range byKey {
+		wg.Add(1)
+		go func(ops []porcupine.Operation) {
+			defer wg.Done()
+			result, info := porcupine.CheckOperationsVerbose(skipmapModel, ops, timeout)
+			if result == porcupine.Illegal {
+				mu.Lock()
+				failures = append(failures, info)
+				mu.Unlock()
+			}
+		}(ops)
+	}
+	wg.Wait()
+
+	return len(failures) == 0, failures
+}
+
+// TestSkipMapLinearizability runs a mixed linearizability test with concurrent
+// clients exercising all skipmap operations on a shared key set.
+func TestSkipMapLinearizability(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping linearizability tests in short mode")
+	}
+
+	const (
+		numClients      = 16
+		numOpsPerClient = 200
+		numKeys         = 10
+	)
+
+	m := NewString()
+	localOps := make([][]porcupine.Operation, numClients)
+	var wg sync.WaitGroup
+	startTime := time.Now()
+
+	for clientId := 0; clientId < numClients; clientId++ {
+		wg.Add(1)
+		go func(cid int) {
+			defer wg.Done()
+			ops := make([]porcupine.Operation, 0, numOpsPerClient)
+
+			for opId := 0; opId < numOpsPerClient; opId++ {
+				key := fmt.Sprintf("key_%d", rand.Intn(numKeys))
+				value := cid*100000 + opId
+				op := rand.Intn(numOps)
+				input := skipmapInput{Op: op, Key: key, Value: value}
+
+				var callTime int64
+				atomic.StoreInt64(&callTime, time.Since(startTime).Nanoseconds())
+				output := executeSkipmapOp(m, input)
+				returnTime := time.Since(startTime).Nanoseconds()
+
+				ops = append(ops, porcupine.Operation{
+					ClientId: cid,
+					Input:    input,
+					Call:     callTime,
+					Output:   output,
+					Return:   returnTime,
+				})
+			}
+			localOps[cid] = ops
+		}(clientId)
+	}
+	wg.Wait()
+
+	var operations []porcupine.Operation
+	for _, ops := range localOps {
+		operations = append(operations, ops...)
+	}
+
+	ok, failures := checkPerKeyLinearizability(operations, 30*time.Second)
+	if !ok {
+		for i, info := range failures {
+			filename := fmt.Sprintf("violation_skipmap_%d_%s.html", i, time.Now().Format("20060102_150405"))
+			if file, err := os.Create(filename); err == nil {
+				porcupine.Visualize(skipmapModel, info, file)
+				file.Close()
+				t.Logf("visualization written to %s", filename)
+			}
+		}
+		t.Fatalf("linearizability violation: %d key(s) failed", len(failures))
+	}
+}

--- a/collection/skipmap/violation_skipmap_1.html
+++ b/collection/skipmap/violation_skipmap_1.html
@@ -1,0 +1,1039 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <title>Porcupine</title>
+    <style>
+      html {
+  font-family: Helvetica, Arial, sans-serif;
+  font-size: 16px;
+}
+
+text {
+  dominant-baseline: middle;
+}
+
+#legend {
+  position: fixed;
+  left: 10px;
+  top: 10px;
+  background-color: rgba(255, 255, 255, 0.5);
+  backdrop-filter: blur(3px);
+  padding: 5px 2px 1px 2px;
+  border-radius: 4px;
+}
+
+#canvas {
+  margin-top: 45px;
+}
+
+#calc {
+  width: 0;
+  height: 0;
+  visibility: hidden;
+}
+
+.bg {
+  fill: transparent;
+}
+
+.divider {
+  stroke: #ccc;
+  stroke-width: 1;
+}
+
+.history-rect {
+  stroke: #888;
+  stroke-width: 1;
+  fill: #42d1f5;
+}
+
+.client-annotation-rect {
+  stroke: #888;
+  stroke-width: 1;
+  fill: #e0e0e0;
+}
+
+.link {
+  fill: #206475;
+  cursor: pointer;
+}
+
+.selected {
+  stroke-width: 5;
+}
+
+.target-rect {
+  opacity: 0;
+}
+
+.history-text {
+  font-size: 0.9rem;
+  font-family:
+    Menlo,
+    Courier New,
+    monospace;
+}
+
+.hidden {
+  opacity: 0.2;
+}
+
+.hidden line {
+  opacity: 0.5; /* note: this is multiplicative */
+}
+
+.linearization {
+  stroke: rgba(0, 0, 0, 0.5);
+}
+
+.linearization-invalid {
+  stroke: rgba(255, 0, 0, 0.5);
+}
+
+.linearization-point {
+  stroke-width: 5;
+}
+
+.linearization-line {
+  stroke-width: 2;
+}
+
+.tooltip {
+  position: absolute;
+  display: none;
+  width: max-content;
+  max-width: 300px;
+  border: 1px solid #ccc;
+  background: white;
+  border-radius: 4px;
+  padding: 5px;
+  font-size: 0.8rem;
+}
+
+.inactive {
+  display: none;
+}
+
+    </style>
+  </head>
+  <body>
+    <div id="legend">
+      <svg xmlns="http://www.w3.org/2000/svg" width="660" height="20">
+        <text x="0" y="10">Clients</text>
+        <line x1="50" y1="0" x2="70" y2="20" stroke="#000" stroke-width="1"></line>
+        <text x="70" y="10">Time</text>
+        <line x1="110" y1="10" x2="200" y2="10" stroke="#000" stroke-width="2"></line>
+        <polygon points="200,5 200,15, 210,10" fill="#000"></polygon>
+        <rect x="300" y="5" width="10" height="10" fill="rgba(0, 0, 0, 0.5)"></rect>
+        <text x="315" y="10">Valid LP</text>
+        <rect x="400" y="5" width="10" height="10" fill="rgba(255, 0, 0, 0.5)"></rect>
+        <text x="415" y="10">Invalid LP</text>
+        <text x="520" y="10" id="jump-link" class="link">[ jump to first error ]</text>
+      </svg>
+    </div>
+    <div id="canvas"></div>
+    <div id="calc"></div>
+    <script>
+      'use strict' // eslint-disable-line unicorn/prefer-module
+
+const SVG_NS = 'http://www.w3.org/2000/svg'
+
+function svgnew(tag, attributes) {
+  const element = document.createElementNS(SVG_NS, tag)
+  svgattr(element, attributes)
+  return element
+}
+
+function svgattr(element, attributes) {
+  if (attributes) {
+    for (const k in attributes) {
+      if (Object.hasOwn(attributes, k)) {
+        element.setAttributeNS(null, k, attributes[k])
+      }
+    }
+  }
+}
+
+function svgattach(parent, child) {
+  // eslint-disable-next-line unicorn/prefer-dom-node-append
+  return parent.appendChild(child)
+}
+
+function svgadd(element, tag, attributes) {
+  return svgattach(element, svgnew(tag, attributes))
+}
+
+function newArray(n, function_) {
+  const array = Array.from({length: n})
+  for (let i = 0; i < n; i++) {
+    array[i] = function_(i)
+  }
+
+  return array
+}
+
+function arrayEq(a, b) {
+  if (a === b) {
+    return true
+  }
+
+  if (a === undefined || a === null || b === undefined || b === null) {
+    return false
+  }
+
+  if (a.length !== b.length) {
+    return false
+  }
+
+  for (const [i, element] of a.entries()) {
+    if (element !== b[i]) {
+      return false
+    }
+  }
+
+  return true
+}
+
+function formatCallReturn(callTime, returnTime) {
+  return '<br><br>Call: ' + callTime + '<br><br>Return: ' + returnTime
+}
+
+// eslint-disable-next-line no-unused-vars, complexity
+function render(data) {
+  const PADDING = 10
+  const BOX_HEIGHT = 30
+  const BOX_SPACE = 15
+  const EPSILON = 20
+  const LINE_BLEED = 5
+  const BOX_GAP = 20
+  const BOX_TEXT_PADDING = 10
+  const HISTORY_RECT_RADIUS = 4
+
+  const annotations = data.Annotations
+  const coreHistory = data.Partitions
+  // For simplicity, make annotations look like more history
+  const allData = [...coreHistory, {History: annotations}]
+
+  let maxClient = -1
+  for (const partition of allData) {
+    for (const element of partition.History) {
+      maxClient = Math.max(maxClient, element.ClientId)
+    }
+  }
+
+  // "real" clients, not including tags
+  const realClients = maxClient + 1
+  // We treat each unique annotation tag as another "client"
+  const tags = new Set()
+  for (const annot of annotations) {
+    const tag = annot.Tag
+    if (tag.length > 0) {
+      tags.add(tag)
+    }
+  }
+
+  // Add synthetic client numbers
+  const tag2ClientId = {}
+  const sortedTags = [...tags].sort()
+  for (const tag of sortedTags) {
+    maxClient += 1
+    tag2ClientId[tag] = maxClient
+  }
+
+  for (const annot of annotations) {
+    const tag = annot.Tag
+    if (tag.length > 0) {
+      annot.ClientId = tag2ClientId[tag]
+    }
+  }
+
+  // Total number of clients now includes these synthetic clients
+  const nClient = maxClient + 1
+
+  // Prepare some useful data to be used later:
+  // - Add a GID to each event
+  // - Create a mapping from GIDs back to events
+  // - Create a set of all timestamps
+  // - Create a set of all start timestamps
+  const allTimestamps = new Set()
+  const startTimestamps = new Set()
+  const endTimestamps = new Set()
+  let gid = 0
+  const byGid = {}
+  for (const partition of allData) {
+    for (const element of partition.History) {
+      allTimestamps.add(element.Start)
+      startTimestamps.add(element.Start)
+      endTimestamps.add(element.End)
+      allTimestamps.add(element.End)
+      // Give elements GIDs
+      element.Gid = gid
+      byGid[gid] = element
+      gid++
+    }
+  }
+
+  let sortedTimestamps = [...allTimestamps].sort((a, b) => a - b)
+
+  // If one event has the same end time as another's start time, that means that
+  // they are concurrent, and we need to display them with overlap. We do this
+  // by tweaking the events that share the end time, updating the time to
+  // end+epsilon, so we have overlap.
+  //
+  // We do not render a good visualization in the situation where a single
+  // client has two events where one has an end time that matches the other's
+  // start time.  There isn't an easy way to handle this, because these two
+  // operations are concurrent (see the comment in model.go for more details for
+  // why it must be this way), and we can't display them with overlap on the
+  // same row cleanly.
+  const epsilon = 16
+  // Coordinated with computeVisualizationData, which uses an incrementing
+  // counter multiplied by 100, so it's safe to adjust timestamps by += epsilon
+  // without it overlapping with another adjusted timestamp (2*16 < 100)
+  for (const [index, partition] of allData.entries()) {
+    if (index === allData.length - 1) {
+      continue // Last partition is the annotations
+    }
+
+    for (const element of partition.History) {
+      const end = element.End
+      if (startTimestamps.has(end)) {
+        element.End = end + epsilon
+        allTimestamps.add(element.End)
+      }
+    }
+  }
+
+  // Handle display of (1) annotations where one has the same end time as
+  // another's start time, and (2) point-in-time annotations, on the same row.
+  //
+  // Unlike operations, where we interpret the start and end times as a closed
+  // interval (and where they have to be displayed with overlap, to be able to
+  // render linearizations and partial linearizations correctly), annotations
+  // are for display purposes only and we can interpret annotations with
+  // different start/end times as open intervals, and render two annotations
+  // with times (a, b) and (b, c) without overlap. We can also handle the
+  // situation where we have a point-in-time annotation with times (b, b).
+  //
+  // This code currently does not handle the case where we have two
+  // point-in-time annotations with the same tag at the same timestamp.
+  //
+  // We keep the annotation adjustment epsilon even smaller (dividing by 2), so
+  // adjusting an event's end time forward by epsilon doesn't overlap with an
+  // annotation's start time that's adjusted forwards (the adjustment of
+  // annotations goes in the opposite direction as that for events).
+  for (const element of allData.at(-1).History) {
+    if (element.End === element.Start) {
+      // Point-in-time annotation: we adjust these to have a non-zero-duration;
+      // we only need to edit the end timestamp, and we can leave the start
+      // as-is
+      element.End += epsilon / 4
+      allTimestamps.add(element.End)
+    } else {
+      // Annotation touching another event or annotation
+      if (startTimestamps.has(element.End)) {
+        element.End -= epsilon / 2
+        allTimestamps.add(element.End)
+      }
+
+      if (endTimestamps.has(element.Start)) {
+        element.Start += epsilon / 2
+        allTimestamps.add(element.Start)
+      }
+    }
+  }
+
+  // Update sortedTimestamps, because we created some new timestamps.
+  sortedTimestamps = [...allTimestamps].sort((a, b) => a - b)
+
+  // Compute layout.
+  //
+  // We warp time to make it easier to see what's going on. We can think
+  // of there being a monotonically increasing mapping from timestamps to
+  // x-positions. This mapping should satisfy some criteria to make the
+  // visualization interpretable:
+  //
+  // - distinguishability: there should be some minimum distance between
+  // unequal timestamps
+  // - visible text: history boxes should be wide enough to fit the text
+  // they contain
+  // - enough space for LPs: history boxes should be wide enough to fit
+  // all linearization points that go through them, while maintaining
+  // readability of linearizations (where each LP in a sequence is spaced
+  // some minimum distance away from the previous one)
+  //
+  // Originally, I thought about this as a linear program:
+  //
+  // - variables for every unique timestamp, x_i = warp(timestamp_i)
+  // - objective: minimize sum x_i
+  // - constraint: non-negative
+  // - constraint: ordering + distinguishability, timestamp_i < timestamp_j -> x_i + EPS < x_j
+  // - constraint: visible text, size_text_j < x_{timestamp_j_end} - x_{timestamp_j_start}
+  // - constraint: linearization lines have points that fit within box, ...
+  //
+  // This used to actually be implemented using an LP solver (without the
+  // linearization point part, though that should be doable too), but
+  // then I realized it's possible to solve optimally using a greedy
+  // left-to-right scan in linear time.
+  //
+  // So that is what we do here. We optimally solve the above, and while
+  // doing so, also compute some useful information (e.g. x-positions of
+  // linearization points) that is useful later.
+  const xPos = {}
+  // Compute some information about history elements, sorted by end time;
+  // the most important information here is box width.
+  const byEnd = allData
+    .flatMap((partition) =>
+      partition.History.map((element) => {
+        // Compute width of the text inside the history element by actually
+        // drawing it (in a hidden div)
+        const scratch = document.querySelector('#calc')
+        scratch.innerHTML = ''
+        const svg = svgadd(scratch, 'svg')
+        const text = svgadd(svg, 'text', {
+          'text-anchor': 'middle',
+          class: 'history-text',
+        })
+        text.textContent = element.Description
+        const bbox = text.getBBox()
+        const width = bbox.width + 2 * BOX_TEXT_PADDING
+        return {
+          start: element.Start,
+          end: element.End,
+          width,
+          gid: element.Gid,
+        }
+      })
+    )
+    .sort((a, b) => a.end - b.end)
+  // Some preprocessing for linearization points and illegal next
+  // linearizations. We need to figure out where exactly LPs end up
+  // as we go, so we can make sure event boxes are wide enough.
+  const eventToLinearizations = newArray(gid, () => []) // Event -> [{index, position}]
+  const eventIllegalLast = newArray(gid, () => []) // Event -> [index]
+  const allLinearizations = []
+  let lgid = 0
+  for (const partition of coreHistory) {
+    for (const lin of partition.PartialLinearizations) {
+      const globalized = [] // Linearization with global indexes instead of partition-local ones
+      const included = new Set() // For figuring out illegal next LPs
+      for (const [position, id] of lin.entries()) {
+        included.add(id.Index)
+        const gid = partition.History[id.Index].Gid
+        globalized.push(gid)
+        eventToLinearizations[gid].push({index: lgid, position})
+      }
+
+      allLinearizations.push(globalized)
+      let minEnd = Infinity
+      for (const [index, element] of partition.History.entries()) {
+        if (!included.has(index)) {
+          minEnd = Math.min(minEnd, element.End)
+        }
+      }
+
+      for (const [index, element] of partition.History.entries()) {
+        if (!included.has(index) && element.Start < minEnd) {
+          eventIllegalLast[element.Gid].push(lgid)
+        }
+      }
+
+      lgid++
+    }
+  }
+
+  const linearizationPositions = newArray(lgid, () => []) // [[xpos]]
+  // Okay, now we're ready to do the left-to-right scan.
+  // Solve timestamp -> xPos.
+  let eventIndex = 0
+  xPos[sortedTimestamps[0]] = 0 // Positions start at 0
+  for (let i = 1; i < sortedTimestamps.length; i++) {
+    // Left-to-right scan, finding minimum time we can use
+    const ts = sortedTimestamps[i]
+    // Ensure some gap from last timestamp
+    let pos = xPos[sortedTimestamps[i - 1]] + BOX_GAP
+    // Ensure that text fits in boxes
+    while (eventIndex < byEnd.length && byEnd[eventIndex].end <= ts) {
+      // Push our position as far as necessary to accommodate text in box
+      const event_ = byEnd[eventIndex]
+      const textEndPos = xPos[event_.start] + event_.width
+      pos = Math.max(pos, textEndPos)
+      // Ensure that LPs fit in box.
+      //
+      // When placing the end of an event, for all partial linearizations
+      // that include that event, for the prefix that comes before that event,
+      // all their start points must have been placed already, so we can figure
+      // out the minimum width that the box needs to be to accommodate the LP.
+      for (const li of [
+        ...eventToLinearizations[event_.gid],
+        ...eventIllegalLast[event_.gid].map((index) => {
+          return {
+            index,
+            position: allLinearizations[index].length - 1,
+          }
+        }),
+      ]) {
+        const {index, position} = li
+        for (let i = linearizationPositions[index].length; i <= position; i++) {
+          // Determine past points
+          let previous = null
+          // eslint-disable-next-line max-depth
+          if (linearizationPositions[index].length > 0) {
+            previous = linearizationPositions[index][i - 1]
+          }
+
+          const nextGid = allLinearizations[index][i]
+          const nextPos =
+            previous === null
+              ? xPos[byGid[nextGid].Start]
+              : Math.max(xPos[byGid[nextGid].Start], previous + EPSILON)
+
+          linearizationPositions[index].push(nextPos)
+        }
+
+        // This next line only really makes sense for the ones in
+        // eventToLinearizations, not the ones from eventIllegalLast,
+        // but it's safe to do it for all points, so we don't bother to
+        // distinguish.
+        pos = Math.max(pos, linearizationPositions[index][position])
+      }
+
+      // Ensure that illegal next LPs fit in box too
+      for (const li of eventIllegalLast[event_.gid]) {
+        const lin = linearizationPositions[li]
+        const previous = lin.at(-1)
+        pos = Math.max(pos, previous + EPSILON)
+      }
+
+      eventIndex++
+    }
+
+    xPos[ts] = pos
+  }
+
+  // Get maximum tag width
+  let maxTagWidth = 0
+  for (let i = 0; i < nClient; i++) {
+    const tag = i < realClients ? i.toString() : sortedTags[i - realClients]
+    const scratch = document.querySelector('#calc')
+    scratch.innerHTML = ''
+    const svg = svgadd(scratch, 'svg')
+    const text = svgadd(svg, 'text', {
+      'text-anchor': 'end',
+    })
+    text.textContent = tag
+    const bbox = text.getBBox()
+    const width = bbox.width + 2 * BOX_TEXT_PADDING
+    if (width > maxTagWidth) {
+      maxTagWidth = width
+    }
+  }
+
+  const t0x = PADDING + maxTagWidth // X-pos of line at t=0
+
+  // Solved, now draw UI.
+
+  let selected = false
+  let selectedIndex = [-1, -1]
+
+  const height = 2 * PADDING + BOX_HEIGHT * nClient + BOX_SPACE * (nClient - 1)
+  const width = 2 * PADDING + maxTagWidth + xPos[sortedTimestamps.at(-1)]
+  const svg = svgadd(document.querySelector('#canvas'), 'svg', {
+    width,
+    height,
+  })
+
+  // Draw background, etc.
+  const bg = svgadd(svg, 'g')
+  const bgRect = svgadd(bg, 'rect', {
+    height,
+    width,
+    x: 0,
+    y: 0,
+    class: 'bg',
+  })
+  bgRect.addEventListener('click', handleBgClick)
+  for (let i = 0; i < nClient; i++) {
+    const text = svgadd(bg, 'text', {
+      x: PADDING + maxTagWidth - BOX_TEXT_PADDING,
+      y: PADDING + BOX_HEIGHT / 2 + i * (BOX_HEIGHT + BOX_SPACE),
+      'text-anchor': 'end',
+    })
+    text.textContent = i < realClients ? i : sortedTags[i - realClients]
+  }
+
+  // Vertical line at t=0
+  svgadd(bg, 'line', {
+    x1: t0x,
+    y1: PADDING,
+    x2: t0x,
+    y2: height - PADDING,
+    class: 'divider',
+  })
+  // Horizontal line dividing clients from annotation tags, but only if there are tags
+  if (tags.size > 0) {
+    const annotationLineY = PADDING + realClients * (BOX_HEIGHT + BOX_SPACE) - BOX_SPACE / 2
+    svgadd(bg, 'line', {
+      x1: PADDING,
+      y1: annotationLineY,
+      x2: t0x,
+      y2: annotationLineY,
+      class: 'divider',
+    })
+  }
+
+  // Draw history
+  const historyLayers = []
+  const historyRects = []
+  const targetRects = svgnew('g')
+  for (const [partitionIndex, partition] of allData.entries()) {
+    const l = svgadd(svg, 'g')
+    historyLayers.push(l)
+    const rects = []
+    for (const [elementIndex, element] of partition.History.entries()) {
+      const g = svgadd(l, 'g')
+      const rx = xPos[element.Start]
+      const width = xPos[element.End] - rx
+      const x = rx + t0x
+      const y = PADDING + element.ClientId * (BOX_HEIGHT + BOX_SPACE)
+      const rectClass = element.Annotation ? 'client-annotation-rect' : 'history-rect'
+      rects.push(
+        svgadd(g, 'rect', {
+          height: BOX_HEIGHT,
+          width,
+          x,
+          y,
+          rx: HISTORY_RECT_RADIUS,
+          ry: HISTORY_RECT_RADIUS,
+          class: rectClass,
+          style:
+            element.Annotation && element.BackgroundColor.length > 0
+              ? `fill: ${element.BackgroundColor};`
+              : '',
+        })
+      )
+      const text = svgadd(g, 'text', {
+        x: x + width / 2,
+        y: y + BOX_HEIGHT / 2,
+        'text-anchor': 'middle',
+        class: 'history-text',
+        style:
+          element.Annotation && element.TextColor.length > 0 ? `fill: ${element.TextColor};` : '',
+      })
+      text.textContent = element.Description
+      // We don't add mouseTarget to g, but to targetRects, because we
+      // want to layer this on top of everything at the end; otherwise, the
+      // LPs and lines will be over the target, which will create holes
+      // where hover etc. won't work
+      const mouseTarget = svgadd(targetRects, 'rect', {
+        height: BOX_HEIGHT,
+        width,
+        x,
+        y,
+        class: 'target-rect',
+        'data-partition': partitionIndex,
+        'data-index': elementIndex,
+      })
+      mouseTarget.addEventListener('mouseover', handleMouseOver)
+      mouseTarget.addEventListener('mousemove', handleMouseMove)
+      mouseTarget.addEventListener('mouseout', handleMouseOut)
+      mouseTarget.addEventListener('click', handleClick)
+    }
+
+    historyRects.push(rects)
+  }
+
+  // Draw partial linearizations
+  const illegalLast = coreHistory.map((partition) => {
+    return partition.PartialLinearizations.map(() => new Set())
+  })
+  const largestIllegal = coreHistory.map(() => {
+    return {}
+  })
+  const largestIllegalLength = coreHistory.map(() => {
+    return {}
+  })
+  const partialLayers = []
+  const errorPoints = []
+  for (const [partitionIndex, partition] of coreHistory.entries()) {
+    const l = []
+    partialLayers.push(l)
+    for (const [linIndex, lin] of partition.PartialLinearizations.entries()) {
+      const g = svgadd(svg, 'g')
+      l.push(g)
+      let previousX = null
+      let previousY = null
+      let previousElement = null
+      const included = new Set()
+      for (const id of lin) {
+        const element = partition.History[id.Index]
+        const hereX = t0x + xPos[element.Start]
+        const x = previousX === null ? hereX : Math.max(hereX, previousX + EPSILON)
+        const y = PADDING + element.ClientId * (BOX_HEIGHT + BOX_SPACE) - LINE_BLEED
+        // Line from previous
+        if (previousElement !== null) {
+          svgadd(g, 'line', {
+            x1: previousX,
+            x2: x,
+            y1:
+              previousElement.ClientId >= element.ClientId
+                ? previousY
+                : previousY + BOX_HEIGHT + 2 * LINE_BLEED,
+            y2: previousElement.ClientId <= element.ClientId ? y : y + BOX_HEIGHT + 2 * LINE_BLEED,
+            class: 'linearization linearization-line',
+          })
+        }
+
+        // Current line
+        svgadd(g, 'line', {
+          x1: x,
+          x2: x,
+          y1: y,
+          y2: y + BOX_HEIGHT + 2 * LINE_BLEED,
+          class: 'linearization linearization-point',
+        })
+        previousX = x
+        previousY = y
+        previousElement = element
+        included.add(id.Index)
+      }
+
+      // Show possible but illegal next linearizations
+      // a history element is a possible next try
+      // if no other history element must be linearized earlier
+      // i.e. forall others, this.start < other.end
+      let minEnd = Infinity
+      for (const [index, element] of partition.History.entries()) {
+        if (!included.has(index)) {
+          minEnd = Math.min(minEnd, element.End)
+        }
+      }
+
+      for (const [index, element] of partition.History.entries()) {
+        if (!included.has(index) && element.Start < minEnd) {
+          const hereX = t0x + xPos[element.Start]
+          const x = previousX === null ? hereX : Math.max(hereX, previousX + EPSILON)
+          const y = PADDING + element.ClientId * (BOX_HEIGHT + BOX_SPACE) - LINE_BLEED
+          // Line from previous
+          svgadd(g, 'line', {
+            x1: previousX,
+            x2: x,
+            y1:
+              previousElement.ClientId >= element.ClientId
+                ? previousY
+                : previousY + BOX_HEIGHT + 2 * LINE_BLEED,
+            y2: previousElement.ClientId <= element.ClientId ? y : y + BOX_HEIGHT + 2 * LINE_BLEED,
+            class: 'linearization-invalid linearization-line',
+          })
+          // Current line
+          const point = svgadd(g, 'line', {
+            x1: x,
+            x2: x,
+            y1: y,
+            y2: y + BOX_HEIGHT + 2 * LINE_BLEED,
+            class: 'linearization-invalid linearization-point',
+          })
+          errorPoints.push({
+            x,
+            partition: partitionIndex,
+            index: lin.at(-1).Index, // NOTE not index
+            element: point,
+          })
+          illegalLast[partitionIndex][linIndex].add(index)
+          // eslint-disable-next-line max-depth
+          if (
+            !Object.hasOwn(largestIllegalLength[partitionIndex], index) ||
+            largestIllegalLength[partitionIndex][index] < lin.length
+          ) {
+            largestIllegalLength[partitionIndex][index] = lin.length
+            largestIllegal[partitionIndex][index] = linIndex
+          }
+        }
+      }
+    }
+  }
+
+  errorPoints.sort((a, b) => a.x - b.x)
+
+  // Attach targetRects
+  svgattach(svg, targetRects)
+
+  // Tooltip
+  // eslint-disable-next-line unicorn/prefer-dom-node-append
+  const tooltip = document.querySelector('#canvas').appendChild(document.createElement('div'))
+  tooltip.setAttribute('class', 'tooltip')
+
+  function handleMouseOver() {
+    if (!selected) {
+      const partition = Number.parseInt(this.dataset.partition, 10)
+      const index = Number.parseInt(this.dataset.index, 10)
+      highlight(partition, index)
+      tooltip.style.display = 'block'
+    }
+  }
+
+  function linearizationIndex(partition, index) {
+    // Show this linearization
+    if (partition >= coreHistory.length) {
+      // Annotation
+      return null
+    }
+
+    if (Object.hasOwn(coreHistory[partition].Largest, index)) {
+      return coreHistory[partition].Largest[index]
+    }
+
+    if (Object.hasOwn(largestIllegal[partition], index)) {
+      return largestIllegal[partition][index]
+    }
+
+    return null
+  }
+
+  function highlight(partition, index) {
+    // Hide all but this partition
+    for (const [i, layer] of historyLayers.entries()) {
+      if (i === partition) {
+        layer.classList.remove('hidden')
+      } else {
+        layer.classList.add('hidden')
+      }
+    }
+
+    // Hide all but the relevant linearization
+    for (const layer of partialLayers) {
+      for (const g of layer) {
+        g.classList.add('hidden')
+      }
+    }
+
+    // Show this linearization
+    const maxIndex = linearizationIndex(partition, index)
+    if (maxIndex !== null) {
+      partialLayers[partition][maxIndex].classList.remove('hidden')
+    }
+
+    updateJump()
+  }
+
+  let lastTooltip = [null, null, null, null, null]
+  function handleMouseMove(event_) {
+    // Keep tooltip static if selected
+    if (selected) {
+      return
+    }
+
+    const partition = Number.parseInt(this.dataset.partition, 10)
+    const index = Number.parseInt(this.dataset.index, 10)
+    const [sPartition, sIndex] = selectedIndex
+    const thisTooltip = [partition, index, selected, sPartition, sIndex]
+
+    if (!arrayEq(lastTooltip, thisTooltip)) {
+      // If selected, show info relevant to the selected linearization
+      const maxIndex = selected
+        ? linearizationIndex(sPartition, sIndex)
+        : linearizationIndex(partition, index)
+
+      const callTime = allData[partition].History[index].OriginalStart
+      const returnTime = allData[partition].History[index].OriginalEnd
+
+      let metadata = ''
+      if (partition < coreHistory.length) {
+        const m = allData[partition].History[index].Metadata
+        if (m !== '') {
+          metadata = m + '<br><br>'
+        }
+      }
+
+      if (partition >= coreHistory.length) {
+        // Annotation
+        const details = annotations[index].Details
+        tooltip.innerHTML = details.length === 0 ? '&langle;no details&rangle;' : details
+      } else if (selected && sPartition !== partition) {
+        tooltip.innerHTML =
+          metadata + 'Not part of selected partition.' + formatCallReturn(callTime, returnTime)
+      } else if (maxIndex === null) {
+        tooltip.innerHTML =
+          metadata +
+          (selected
+            ? 'Selected element is not part of any partial linearization.'
+            : 'Not part of any partial linearization.') +
+          formatCallReturn(callTime, returnTime)
+      } else {
+        const lin = coreHistory[partition].PartialLinearizations[maxIndex]
+        let previous = null
+        let current = null
+        let found = false
+        for (const element of lin) {
+          previous = current
+          current = element
+          if (current.Index === index) {
+            found = true
+            break
+          }
+        }
+
+        let message = metadata
+
+        if (found) {
+          // Part of linearization
+          if (previous !== null) {
+            message +=
+              '<strong>Previous state:</strong><br>' + previous.StateDescription + '<br><br>'
+          }
+
+          message +=
+            '<strong>New state:</strong><br>' +
+            current.StateDescription +
+            formatCallReturn(callTime, returnTime)
+        } else if (illegalLast[partition][maxIndex].has(index)) {
+          // Illegal next one
+          message +=
+            '<strong>Previous state:</strong><br>' +
+            lin.at(-1).StateDescription +
+            '<br><br><strong>New state:</strong><br>&langle;invalid op&rangle;' +
+            formatCallReturn(callTime, returnTime)
+        } else {
+          // Not part of this one
+          message +=
+            "Not part of selected element's partial linearization." +
+            formatCallReturn(callTime, returnTime)
+        }
+
+        tooltip.innerHTML = message
+      }
+
+      lastTooltip = thisTooltip
+    }
+
+    // Make sure tooltip doesn't overflow off the right side of the screen
+    const maxX =
+      document.documentElement.scrollLeft +
+      document.documentElement.clientWidth -
+      PADDING -
+      tooltip.getBoundingClientRect().width
+    tooltip.style.left = Math.min(event_.pageX + 20, maxX) + 'px'
+    tooltip.style.top = event_.pageY + 20 + 'px'
+  }
+
+  function handleMouseOut() {
+    if (!selected) {
+      resetHighlight()
+      tooltip.style.display = 'none'
+      lastTooltip = [null, null, null, null, null]
+    }
+  }
+
+  function resetHighlight() {
+    // Show all layers
+    for (const layer of historyLayers) {
+      layer.classList.remove('hidden')
+    }
+
+    // Show longest linearizations, which are first
+    for (const layers of partialLayers) {
+      for (const [i, l] of layers.entries()) {
+        if (i === 0) {
+          l.classList.remove('hidden')
+        } else {
+          l.classList.add('hidden')
+        }
+      }
+    }
+
+    updateJump()
+  }
+
+  // Store jump click handler so we can remove it before adding a new one
+  let jumpClickHandler = null
+
+  function updateJump() {
+    const jump = document.querySelector('#jump-link')
+    // Find first non-hidden point
+    // feels a little hacky, but it works
+    const point = errorPoints.find((pt) => !pt.element.parentElement.classList.contains('hidden'))
+
+    // Remove any existing event listener
+    if (jumpClickHandler) {
+      jump.removeEventListener('click', jumpClickHandler)
+      jumpClickHandler = null
+    }
+
+    if (point) {
+      jump.classList.remove('inactive')
+      jumpClickHandler = () => {
+        point.element.scrollIntoView({behavior: 'smooth', inline: 'center', block: 'center'})
+        if (!selected) {
+          select(point.partition, point.index)
+        }
+      }
+
+      jump.addEventListener('click', jumpClickHandler)
+    } else {
+      jump.classList.add('inactive')
+    }
+  }
+
+  function handleClick(event_) {
+    const partition = Number.parseInt(this.dataset.partition, 10)
+    const index = Number.parseInt(this.dataset.index, 10)
+    if (selected) {
+      const [sPartition, sIndex] = selectedIndex
+      if (partition === sPartition && index === sIndex) {
+        deselect()
+        // Note: we're still displaying the tooltip, but once the user's mouse moves, it'll get updated
+        return
+      }
+
+      historyRects[sPartition][sIndex].classList.remove('selected')
+    }
+
+    select(partition, index)
+
+    tooltip.style.display = 'block'
+    // Set static tooltip position when selecting
+    const maxX =
+      document.documentElement.scrollLeft +
+      document.documentElement.clientWidth -
+      PADDING -
+      tooltip.getBoundingClientRect().width
+    tooltip.style.left = Math.min(event_.pageX + 20, maxX) + 'px'
+    tooltip.style.top = event_.pageY + 20 + 'px'
+  }
+
+  function handleBgClick() {
+    deselect()
+
+    tooltip.style.display = 'none'
+    lastTooltip = [null, null, null, null, null]
+  }
+
+  function select(partition, index) {
+    selected = true
+    selectedIndex = [partition, index]
+    highlight(partition, index)
+    historyRects[partition][index].classList.add('selected')
+  }
+
+  function deselect() {
+    if (!selected) {
+      return
+    }
+
+    selected = false
+    resetHighlight()
+    const [partition, index] = selectedIndex
+    historyRects[partition][index].classList.remove('selected')
+  }
+
+  handleMouseOut() // Initialize, same as mouse out
+}
+
+
+      const data = {"Partitions":[{"History":[{"ClientId":2,"Start":0,"OriginalStart":"81208","End":100,"OriginalEnd":"81625","Description":"LoadOrStore(key-0, 1) -\u003e loaded=false value=1","Metadata":""},{"ClientId":2,"Start":200,"OriginalStart":"85666","End":300,"OriginalEnd":"85750","Description":"Load(key-0) -\u003e found=true value=1","Metadata":""},{"ClientId":2,"Start":400,"OriginalStart":"85833","End":500,"OriginalEnd":"85875","Description":"Load(key-0) -\u003e found=true value=1","Metadata":""},{"ClientId":2,"Start":600,"OriginalStart":"86458","End":700,"OriginalEnd":"86500","Description":"LoadOrStoreLazy(key-0, \u003cfn:-2266\u003e) -\u003e loaded=true value=1","Metadata":""},{"ClientId":2,"Start":800,"OriginalStart":"89875","End":900,"OriginalEnd":"89916","Description":"Load(key-0) -\u003e found=true value=1","Metadata":""},{"ClientId":2,"Start":1000,"OriginalStart":"91125","End":1100,"OriginalEnd":"91291","Description":"Store(key-0, 375)","Metadata":""},{"ClientId":1,"Start":1200,"OriginalStart":"94833","End":1300,"OriginalEnd":"95500","Description":"Store(key-0, 30)","Metadata":""},{"ClientId":2,"Start":1400,"OriginalStart":"101500","End":1500,"OriginalEnd":"101750","Description":"Load(key-0) -\u003e found=true value=30","Metadata":""},{"ClientId":2,"Start":1600,"OriginalStart":"107166","End":1700,"OriginalEnd":"107250","Description":"Load(key-0) -\u003e found=true value=30","Metadata":""},{"ClientId":2,"Start":1800,"OriginalStart":"107625","End":1900,"OriginalEnd":"107916","Description":"Store(key-0, -280)","Metadata":""},{"ClientId":2,"Start":2000,"OriginalStart":"107958","End":2100,"OriginalEnd":"108041","Description":"Load(key-0) -\u003e found=true value=-280","Metadata":""},{"ClientId":1,"Start":2200,"OriginalStart":"111458","End":2300,"OriginalEnd":"111583","Description":"Load(key-0) -\u003e found=true value=-280","Metadata":""},{"ClientId":0,"Start":2400,"OriginalStart":"112166","End":2500,"OriginalEnd":"112625","Description":"LoadOrStore(key-0, 1000000) -\u003e loaded=true value=-280","Metadata":""},{"ClientId":0,"Start":2600,"OriginalStart":"113041","End":2700,"OriginalEnd":"113291","Description":"LoadOrStoreLazy(key-0, \u003cfn:304\u003e) -\u003e loaded=true value=-280","Metadata":""},{"ClientId":0,"Start":2800,"OriginalStart":"113416","End":2900,"OriginalEnd":"113541","Description":"Load(key-0) -\u003e found=true value=-280","Metadata":""},{"ClientId":2,"Start":2800,"OriginalStart":"113416","End":2900,"OriginalEnd":"113541","Description":"Load(key-0) -\u003e found=true value=-280","Metadata":""},{"ClientId":0,"Start":3000,"OriginalStart":"114208","End":3100,"OriginalEnd":"114333","Description":"Load(key-0) -\u003e found=true value=-280","Metadata":""},{"ClientId":0,"Start":3200,"OriginalStart":"114375","End":3500,"OriginalEnd":"114916","Description":"Store(key-0, 1)","Metadata":""},{"ClientId":2,"Start":3300,"OriginalStart":"114416","End":3400,"OriginalEnd":"114666","Description":"LoadAndDelete(key-0) -\u003e loaded=true value=-280","Metadata":""},{"ClientId":2,"Start":3600,"OriginalStart":"115166","End":3700,"OriginalEnd":"115250","Description":"Load(key-0) -\u003e found=false value=0","Metadata":""},{"ClientId":2,"Start":3800,"OriginalStart":"115750","End":3900,"OriginalEnd":"116000","Description":"LoadOrStoreLazy(key-0, \u003cfn:130\u003e) -\u003e loaded=false value=130","Metadata":""},{"ClientId":2,"Start":4000,"OriginalStart":"116083","End":4100,"OriginalEnd":"116166","Description":"Load(key-0) -\u003e found=true value=130","Metadata":""},{"ClientId":1,"Start":4200,"OriginalStart":"116291","End":4300,"OriginalEnd":"116458","Description":"Load(key-0) -\u003e found=true value=130","Metadata":""},{"ClientId":1,"Start":4400,"OriginalStart":"116541","End":4500,"OriginalEnd":"116708","Description":"Store(key-0, 0)","Metadata":""},{"ClientId":2,"Start":4600,"OriginalStart":"116750","End":4800,"OriginalEnd":"116875","Description":"Load(key-0) -\u003e found=true value=0","Metadata":""},{"ClientId":0,"Start":4700,"OriginalStart":"116791","End":4900,"OriginalEnd":"117125","Description":"LoadAndDelete(key-0) -\u003e loaded=true value=0","Metadata":""},{"ClientId":0,"Start":5000,"OriginalStart":"134333","End":5100,"OriginalEnd":"134416","Description":"Load(key-0) -\u003e found=false value=0","Metadata":""},{"ClientId":1,"Start":5200,"OriginalStart":"135416","End":5300,"OriginalEnd":"135500","Description":"Load(key-0) -\u003e found=false value=0","Metadata":""},{"ClientId":1,"Start":5400,"OriginalStart":"137458","End":5500,"OriginalEnd":"137500","Description":"Load(key-0) -\u003e found=false value=0","Metadata":""},{"ClientId":0,"Start":5400,"OriginalStart":"137458","End":5600,"OriginalEnd":"137708","Description":"Store(key-0, 29671)","Metadata":""},{"ClientId":1,"Start":5600,"OriginalStart":"137708","End":5700,"OriginalEnd":"137833","Description":"Load(key-0) -\u003e found=true value=29671","Metadata":""},{"ClientId":0,"Start":5800,"OriginalStart":"138000","End":5900,"OriginalEnd":"138125","Description":"Store(key-0, 4503)","Metadata":""},{"ClientId":1,"Start":6000,"OriginalStart":"138625","End":6100,"OriginalEnd":"138708","Description":"Load(key-0) -\u003e found=true value=4503","Metadata":""},{"ClientId":0,"Start":6200,"OriginalStart":"138875","End":6300,"OriginalEnd":"138958","Description":"Load(key-0) -\u003e found=true value=4503","Metadata":""},{"ClientId":1,"Start":6400,"OriginalStart":"139125","End":6500,"OriginalEnd":"139166","Description":"Load(key-0) -\u003e found=true value=4503","Metadata":""},{"ClientId":0,"Start":6600,"OriginalStart":"139541","End":6700,"OriginalEnd":"139625","Description":"Load(key-0) -\u003e found=true value=4503","Metadata":""},{"ClientId":0,"Start":6800,"OriginalStart":"143458","End":6900,"OriginalEnd":"143625","Description":"Store(key-0, -155)","Metadata":""},{"ClientId":0,"Start":7000,"OriginalStart":"144291","End":7100,"OriginalEnd":"144375","Description":"Load(key-0) -\u003e found=true value=-155","Metadata":""},{"ClientId":0,"Start":7200,"OriginalStart":"144875","End":7300,"OriginalEnd":"145041","Description":"Delete(key-0) -\u003e deleted=true","Metadata":""},{"ClientId":1,"Start":7400,"OriginalStart":"148291","End":7500,"OriginalEnd":"149666","Description":"LoadOrStore(key-0, -25) -\u003e loaded=false value=-25","Metadata":""}],"PartialLinearizations":[[{"Index":0,"StateDescription":"value=1"},{"Index":1,"StateDescription":"value=1"},{"Index":2,"StateDescription":"value=1"},{"Index":3,"StateDescription":"value=1"},{"Index":4,"StateDescription":"value=1"},{"Index":5,"StateDescription":"value=375"},{"Index":6,"StateDescription":"value=30"},{"Index":7,"StateDescription":"value=30"},{"Index":8,"StateDescription":"value=30"},{"Index":9,"StateDescription":"value=-280"},{"Index":10,"StateDescription":"value=-280"},{"Index":11,"StateDescription":"value=-280"},{"Index":12,"StateDescription":"value=-280"},{"Index":13,"StateDescription":"value=-280"},{"Index":15,"StateDescription":"value=-280"},{"Index":14,"StateDescription":"value=-280"},{"Index":16,"StateDescription":"value=-280"},{"Index":18,"StateDescription":"absent"},{"Index":17,"StateDescription":"value=1"}]],"Largest":{"0":0,"1":0,"10":0,"11":0,"12":0,"13":0,"14":0,"15":0,"16":0,"17":0,"18":0,"2":0,"3":0,"4":0,"5":0,"6":0,"7":0,"8":0,"9":0}}],"Annotations":[]}
+
+      render(data)
+    </script>
+  </body>
+</html>

--- a/collection/skipmap/violation_skipmap_2.html
+++ b/collection/skipmap/violation_skipmap_2.html
@@ -1,0 +1,1039 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <title>Porcupine</title>
+    <style>
+      html {
+  font-family: Helvetica, Arial, sans-serif;
+  font-size: 16px;
+}
+
+text {
+  dominant-baseline: middle;
+}
+
+#legend {
+  position: fixed;
+  left: 10px;
+  top: 10px;
+  background-color: rgba(255, 255, 255, 0.5);
+  backdrop-filter: blur(3px);
+  padding: 5px 2px 1px 2px;
+  border-radius: 4px;
+}
+
+#canvas {
+  margin-top: 45px;
+}
+
+#calc {
+  width: 0;
+  height: 0;
+  visibility: hidden;
+}
+
+.bg {
+  fill: transparent;
+}
+
+.divider {
+  stroke: #ccc;
+  stroke-width: 1;
+}
+
+.history-rect {
+  stroke: #888;
+  stroke-width: 1;
+  fill: #42d1f5;
+}
+
+.client-annotation-rect {
+  stroke: #888;
+  stroke-width: 1;
+  fill: #e0e0e0;
+}
+
+.link {
+  fill: #206475;
+  cursor: pointer;
+}
+
+.selected {
+  stroke-width: 5;
+}
+
+.target-rect {
+  opacity: 0;
+}
+
+.history-text {
+  font-size: 0.9rem;
+  font-family:
+    Menlo,
+    Courier New,
+    monospace;
+}
+
+.hidden {
+  opacity: 0.2;
+}
+
+.hidden line {
+  opacity: 0.5; /* note: this is multiplicative */
+}
+
+.linearization {
+  stroke: rgba(0, 0, 0, 0.5);
+}
+
+.linearization-invalid {
+  stroke: rgba(255, 0, 0, 0.5);
+}
+
+.linearization-point {
+  stroke-width: 5;
+}
+
+.linearization-line {
+  stroke-width: 2;
+}
+
+.tooltip {
+  position: absolute;
+  display: none;
+  width: max-content;
+  max-width: 300px;
+  border: 1px solid #ccc;
+  background: white;
+  border-radius: 4px;
+  padding: 5px;
+  font-size: 0.8rem;
+}
+
+.inactive {
+  display: none;
+}
+
+    </style>
+  </head>
+  <body>
+    <div id="legend">
+      <svg xmlns="http://www.w3.org/2000/svg" width="660" height="20">
+        <text x="0" y="10">Clients</text>
+        <line x1="50" y1="0" x2="70" y2="20" stroke="#000" stroke-width="1"></line>
+        <text x="70" y="10">Time</text>
+        <line x1="110" y1="10" x2="200" y2="10" stroke="#000" stroke-width="2"></line>
+        <polygon points="200,5 200,15, 210,10" fill="#000"></polygon>
+        <rect x="300" y="5" width="10" height="10" fill="rgba(0, 0, 0, 0.5)"></rect>
+        <text x="315" y="10">Valid LP</text>
+        <rect x="400" y="5" width="10" height="10" fill="rgba(255, 0, 0, 0.5)"></rect>
+        <text x="415" y="10">Invalid LP</text>
+        <text x="520" y="10" id="jump-link" class="link">[ jump to first error ]</text>
+      </svg>
+    </div>
+    <div id="canvas"></div>
+    <div id="calc"></div>
+    <script>
+      'use strict' // eslint-disable-line unicorn/prefer-module
+
+const SVG_NS = 'http://www.w3.org/2000/svg'
+
+function svgnew(tag, attributes) {
+  const element = document.createElementNS(SVG_NS, tag)
+  svgattr(element, attributes)
+  return element
+}
+
+function svgattr(element, attributes) {
+  if (attributes) {
+    for (const k in attributes) {
+      if (Object.hasOwn(attributes, k)) {
+        element.setAttributeNS(null, k, attributes[k])
+      }
+    }
+  }
+}
+
+function svgattach(parent, child) {
+  // eslint-disable-next-line unicorn/prefer-dom-node-append
+  return parent.appendChild(child)
+}
+
+function svgadd(element, tag, attributes) {
+  return svgattach(element, svgnew(tag, attributes))
+}
+
+function newArray(n, function_) {
+  const array = Array.from({length: n})
+  for (let i = 0; i < n; i++) {
+    array[i] = function_(i)
+  }
+
+  return array
+}
+
+function arrayEq(a, b) {
+  if (a === b) {
+    return true
+  }
+
+  if (a === undefined || a === null || b === undefined || b === null) {
+    return false
+  }
+
+  if (a.length !== b.length) {
+    return false
+  }
+
+  for (const [i, element] of a.entries()) {
+    if (element !== b[i]) {
+      return false
+    }
+  }
+
+  return true
+}
+
+function formatCallReturn(callTime, returnTime) {
+  return '<br><br>Call: ' + callTime + '<br><br>Return: ' + returnTime
+}
+
+// eslint-disable-next-line no-unused-vars, complexity
+function render(data) {
+  const PADDING = 10
+  const BOX_HEIGHT = 30
+  const BOX_SPACE = 15
+  const EPSILON = 20
+  const LINE_BLEED = 5
+  const BOX_GAP = 20
+  const BOX_TEXT_PADDING = 10
+  const HISTORY_RECT_RADIUS = 4
+
+  const annotations = data.Annotations
+  const coreHistory = data.Partitions
+  // For simplicity, make annotations look like more history
+  const allData = [...coreHistory, {History: annotations}]
+
+  let maxClient = -1
+  for (const partition of allData) {
+    for (const element of partition.History) {
+      maxClient = Math.max(maxClient, element.ClientId)
+    }
+  }
+
+  // "real" clients, not including tags
+  const realClients = maxClient + 1
+  // We treat each unique annotation tag as another "client"
+  const tags = new Set()
+  for (const annot of annotations) {
+    const tag = annot.Tag
+    if (tag.length > 0) {
+      tags.add(tag)
+    }
+  }
+
+  // Add synthetic client numbers
+  const tag2ClientId = {}
+  const sortedTags = [...tags].sort()
+  for (const tag of sortedTags) {
+    maxClient += 1
+    tag2ClientId[tag] = maxClient
+  }
+
+  for (const annot of annotations) {
+    const tag = annot.Tag
+    if (tag.length > 0) {
+      annot.ClientId = tag2ClientId[tag]
+    }
+  }
+
+  // Total number of clients now includes these synthetic clients
+  const nClient = maxClient + 1
+
+  // Prepare some useful data to be used later:
+  // - Add a GID to each event
+  // - Create a mapping from GIDs back to events
+  // - Create a set of all timestamps
+  // - Create a set of all start timestamps
+  const allTimestamps = new Set()
+  const startTimestamps = new Set()
+  const endTimestamps = new Set()
+  let gid = 0
+  const byGid = {}
+  for (const partition of allData) {
+    for (const element of partition.History) {
+      allTimestamps.add(element.Start)
+      startTimestamps.add(element.Start)
+      endTimestamps.add(element.End)
+      allTimestamps.add(element.End)
+      // Give elements GIDs
+      element.Gid = gid
+      byGid[gid] = element
+      gid++
+    }
+  }
+
+  let sortedTimestamps = [...allTimestamps].sort((a, b) => a - b)
+
+  // If one event has the same end time as another's start time, that means that
+  // they are concurrent, and we need to display them with overlap. We do this
+  // by tweaking the events that share the end time, updating the time to
+  // end+epsilon, so we have overlap.
+  //
+  // We do not render a good visualization in the situation where a single
+  // client has two events where one has an end time that matches the other's
+  // start time.  There isn't an easy way to handle this, because these two
+  // operations are concurrent (see the comment in model.go for more details for
+  // why it must be this way), and we can't display them with overlap on the
+  // same row cleanly.
+  const epsilon = 16
+  // Coordinated with computeVisualizationData, which uses an incrementing
+  // counter multiplied by 100, so it's safe to adjust timestamps by += epsilon
+  // without it overlapping with another adjusted timestamp (2*16 < 100)
+  for (const [index, partition] of allData.entries()) {
+    if (index === allData.length - 1) {
+      continue // Last partition is the annotations
+    }
+
+    for (const element of partition.History) {
+      const end = element.End
+      if (startTimestamps.has(end)) {
+        element.End = end + epsilon
+        allTimestamps.add(element.End)
+      }
+    }
+  }
+
+  // Handle display of (1) annotations where one has the same end time as
+  // another's start time, and (2) point-in-time annotations, on the same row.
+  //
+  // Unlike operations, where we interpret the start and end times as a closed
+  // interval (and where they have to be displayed with overlap, to be able to
+  // render linearizations and partial linearizations correctly), annotations
+  // are for display purposes only and we can interpret annotations with
+  // different start/end times as open intervals, and render two annotations
+  // with times (a, b) and (b, c) without overlap. We can also handle the
+  // situation where we have a point-in-time annotation with times (b, b).
+  //
+  // This code currently does not handle the case where we have two
+  // point-in-time annotations with the same tag at the same timestamp.
+  //
+  // We keep the annotation adjustment epsilon even smaller (dividing by 2), so
+  // adjusting an event's end time forward by epsilon doesn't overlap with an
+  // annotation's start time that's adjusted forwards (the adjustment of
+  // annotations goes in the opposite direction as that for events).
+  for (const element of allData.at(-1).History) {
+    if (element.End === element.Start) {
+      // Point-in-time annotation: we adjust these to have a non-zero-duration;
+      // we only need to edit the end timestamp, and we can leave the start
+      // as-is
+      element.End += epsilon / 4
+      allTimestamps.add(element.End)
+    } else {
+      // Annotation touching another event or annotation
+      if (startTimestamps.has(element.End)) {
+        element.End -= epsilon / 2
+        allTimestamps.add(element.End)
+      }
+
+      if (endTimestamps.has(element.Start)) {
+        element.Start += epsilon / 2
+        allTimestamps.add(element.Start)
+      }
+    }
+  }
+
+  // Update sortedTimestamps, because we created some new timestamps.
+  sortedTimestamps = [...allTimestamps].sort((a, b) => a - b)
+
+  // Compute layout.
+  //
+  // We warp time to make it easier to see what's going on. We can think
+  // of there being a monotonically increasing mapping from timestamps to
+  // x-positions. This mapping should satisfy some criteria to make the
+  // visualization interpretable:
+  //
+  // - distinguishability: there should be some minimum distance between
+  // unequal timestamps
+  // - visible text: history boxes should be wide enough to fit the text
+  // they contain
+  // - enough space for LPs: history boxes should be wide enough to fit
+  // all linearization points that go through them, while maintaining
+  // readability of linearizations (where each LP in a sequence is spaced
+  // some minimum distance away from the previous one)
+  //
+  // Originally, I thought about this as a linear program:
+  //
+  // - variables for every unique timestamp, x_i = warp(timestamp_i)
+  // - objective: minimize sum x_i
+  // - constraint: non-negative
+  // - constraint: ordering + distinguishability, timestamp_i < timestamp_j -> x_i + EPS < x_j
+  // - constraint: visible text, size_text_j < x_{timestamp_j_end} - x_{timestamp_j_start}
+  // - constraint: linearization lines have points that fit within box, ...
+  //
+  // This used to actually be implemented using an LP solver (without the
+  // linearization point part, though that should be doable too), but
+  // then I realized it's possible to solve optimally using a greedy
+  // left-to-right scan in linear time.
+  //
+  // So that is what we do here. We optimally solve the above, and while
+  // doing so, also compute some useful information (e.g. x-positions of
+  // linearization points) that is useful later.
+  const xPos = {}
+  // Compute some information about history elements, sorted by end time;
+  // the most important information here is box width.
+  const byEnd = allData
+    .flatMap((partition) =>
+      partition.History.map((element) => {
+        // Compute width of the text inside the history element by actually
+        // drawing it (in a hidden div)
+        const scratch = document.querySelector('#calc')
+        scratch.innerHTML = ''
+        const svg = svgadd(scratch, 'svg')
+        const text = svgadd(svg, 'text', {
+          'text-anchor': 'middle',
+          class: 'history-text',
+        })
+        text.textContent = element.Description
+        const bbox = text.getBBox()
+        const width = bbox.width + 2 * BOX_TEXT_PADDING
+        return {
+          start: element.Start,
+          end: element.End,
+          width,
+          gid: element.Gid,
+        }
+      })
+    )
+    .sort((a, b) => a.end - b.end)
+  // Some preprocessing for linearization points and illegal next
+  // linearizations. We need to figure out where exactly LPs end up
+  // as we go, so we can make sure event boxes are wide enough.
+  const eventToLinearizations = newArray(gid, () => []) // Event -> [{index, position}]
+  const eventIllegalLast = newArray(gid, () => []) // Event -> [index]
+  const allLinearizations = []
+  let lgid = 0
+  for (const partition of coreHistory) {
+    for (const lin of partition.PartialLinearizations) {
+      const globalized = [] // Linearization with global indexes instead of partition-local ones
+      const included = new Set() // For figuring out illegal next LPs
+      for (const [position, id] of lin.entries()) {
+        included.add(id.Index)
+        const gid = partition.History[id.Index].Gid
+        globalized.push(gid)
+        eventToLinearizations[gid].push({index: lgid, position})
+      }
+
+      allLinearizations.push(globalized)
+      let minEnd = Infinity
+      for (const [index, element] of partition.History.entries()) {
+        if (!included.has(index)) {
+          minEnd = Math.min(minEnd, element.End)
+        }
+      }
+
+      for (const [index, element] of partition.History.entries()) {
+        if (!included.has(index) && element.Start < minEnd) {
+          eventIllegalLast[element.Gid].push(lgid)
+        }
+      }
+
+      lgid++
+    }
+  }
+
+  const linearizationPositions = newArray(lgid, () => []) // [[xpos]]
+  // Okay, now we're ready to do the left-to-right scan.
+  // Solve timestamp -> xPos.
+  let eventIndex = 0
+  xPos[sortedTimestamps[0]] = 0 // Positions start at 0
+  for (let i = 1; i < sortedTimestamps.length; i++) {
+    // Left-to-right scan, finding minimum time we can use
+    const ts = sortedTimestamps[i]
+    // Ensure some gap from last timestamp
+    let pos = xPos[sortedTimestamps[i - 1]] + BOX_GAP
+    // Ensure that text fits in boxes
+    while (eventIndex < byEnd.length && byEnd[eventIndex].end <= ts) {
+      // Push our position as far as necessary to accommodate text in box
+      const event_ = byEnd[eventIndex]
+      const textEndPos = xPos[event_.start] + event_.width
+      pos = Math.max(pos, textEndPos)
+      // Ensure that LPs fit in box.
+      //
+      // When placing the end of an event, for all partial linearizations
+      // that include that event, for the prefix that comes before that event,
+      // all their start points must have been placed already, so we can figure
+      // out the minimum width that the box needs to be to accommodate the LP.
+      for (const li of [
+        ...eventToLinearizations[event_.gid],
+        ...eventIllegalLast[event_.gid].map((index) => {
+          return {
+            index,
+            position: allLinearizations[index].length - 1,
+          }
+        }),
+      ]) {
+        const {index, position} = li
+        for (let i = linearizationPositions[index].length; i <= position; i++) {
+          // Determine past points
+          let previous = null
+          // eslint-disable-next-line max-depth
+          if (linearizationPositions[index].length > 0) {
+            previous = linearizationPositions[index][i - 1]
+          }
+
+          const nextGid = allLinearizations[index][i]
+          const nextPos =
+            previous === null
+              ? xPos[byGid[nextGid].Start]
+              : Math.max(xPos[byGid[nextGid].Start], previous + EPSILON)
+
+          linearizationPositions[index].push(nextPos)
+        }
+
+        // This next line only really makes sense for the ones in
+        // eventToLinearizations, not the ones from eventIllegalLast,
+        // but it's safe to do it for all points, so we don't bother to
+        // distinguish.
+        pos = Math.max(pos, linearizationPositions[index][position])
+      }
+
+      // Ensure that illegal next LPs fit in box too
+      for (const li of eventIllegalLast[event_.gid]) {
+        const lin = linearizationPositions[li]
+        const previous = lin.at(-1)
+        pos = Math.max(pos, previous + EPSILON)
+      }
+
+      eventIndex++
+    }
+
+    xPos[ts] = pos
+  }
+
+  // Get maximum tag width
+  let maxTagWidth = 0
+  for (let i = 0; i < nClient; i++) {
+    const tag = i < realClients ? i.toString() : sortedTags[i - realClients]
+    const scratch = document.querySelector('#calc')
+    scratch.innerHTML = ''
+    const svg = svgadd(scratch, 'svg')
+    const text = svgadd(svg, 'text', {
+      'text-anchor': 'end',
+    })
+    text.textContent = tag
+    const bbox = text.getBBox()
+    const width = bbox.width + 2 * BOX_TEXT_PADDING
+    if (width > maxTagWidth) {
+      maxTagWidth = width
+    }
+  }
+
+  const t0x = PADDING + maxTagWidth // X-pos of line at t=0
+
+  // Solved, now draw UI.
+
+  let selected = false
+  let selectedIndex = [-1, -1]
+
+  const height = 2 * PADDING + BOX_HEIGHT * nClient + BOX_SPACE * (nClient - 1)
+  const width = 2 * PADDING + maxTagWidth + xPos[sortedTimestamps.at(-1)]
+  const svg = svgadd(document.querySelector('#canvas'), 'svg', {
+    width,
+    height,
+  })
+
+  // Draw background, etc.
+  const bg = svgadd(svg, 'g')
+  const bgRect = svgadd(bg, 'rect', {
+    height,
+    width,
+    x: 0,
+    y: 0,
+    class: 'bg',
+  })
+  bgRect.addEventListener('click', handleBgClick)
+  for (let i = 0; i < nClient; i++) {
+    const text = svgadd(bg, 'text', {
+      x: PADDING + maxTagWidth - BOX_TEXT_PADDING,
+      y: PADDING + BOX_HEIGHT / 2 + i * (BOX_HEIGHT + BOX_SPACE),
+      'text-anchor': 'end',
+    })
+    text.textContent = i < realClients ? i : sortedTags[i - realClients]
+  }
+
+  // Vertical line at t=0
+  svgadd(bg, 'line', {
+    x1: t0x,
+    y1: PADDING,
+    x2: t0x,
+    y2: height - PADDING,
+    class: 'divider',
+  })
+  // Horizontal line dividing clients from annotation tags, but only if there are tags
+  if (tags.size > 0) {
+    const annotationLineY = PADDING + realClients * (BOX_HEIGHT + BOX_SPACE) - BOX_SPACE / 2
+    svgadd(bg, 'line', {
+      x1: PADDING,
+      y1: annotationLineY,
+      x2: t0x,
+      y2: annotationLineY,
+      class: 'divider',
+    })
+  }
+
+  // Draw history
+  const historyLayers = []
+  const historyRects = []
+  const targetRects = svgnew('g')
+  for (const [partitionIndex, partition] of allData.entries()) {
+    const l = svgadd(svg, 'g')
+    historyLayers.push(l)
+    const rects = []
+    for (const [elementIndex, element] of partition.History.entries()) {
+      const g = svgadd(l, 'g')
+      const rx = xPos[element.Start]
+      const width = xPos[element.End] - rx
+      const x = rx + t0x
+      const y = PADDING + element.ClientId * (BOX_HEIGHT + BOX_SPACE)
+      const rectClass = element.Annotation ? 'client-annotation-rect' : 'history-rect'
+      rects.push(
+        svgadd(g, 'rect', {
+          height: BOX_HEIGHT,
+          width,
+          x,
+          y,
+          rx: HISTORY_RECT_RADIUS,
+          ry: HISTORY_RECT_RADIUS,
+          class: rectClass,
+          style:
+            element.Annotation && element.BackgroundColor.length > 0
+              ? `fill: ${element.BackgroundColor};`
+              : '',
+        })
+      )
+      const text = svgadd(g, 'text', {
+        x: x + width / 2,
+        y: y + BOX_HEIGHT / 2,
+        'text-anchor': 'middle',
+        class: 'history-text',
+        style:
+          element.Annotation && element.TextColor.length > 0 ? `fill: ${element.TextColor};` : '',
+      })
+      text.textContent = element.Description
+      // We don't add mouseTarget to g, but to targetRects, because we
+      // want to layer this on top of everything at the end; otherwise, the
+      // LPs and lines will be over the target, which will create holes
+      // where hover etc. won't work
+      const mouseTarget = svgadd(targetRects, 'rect', {
+        height: BOX_HEIGHT,
+        width,
+        x,
+        y,
+        class: 'target-rect',
+        'data-partition': partitionIndex,
+        'data-index': elementIndex,
+      })
+      mouseTarget.addEventListener('mouseover', handleMouseOver)
+      mouseTarget.addEventListener('mousemove', handleMouseMove)
+      mouseTarget.addEventListener('mouseout', handleMouseOut)
+      mouseTarget.addEventListener('click', handleClick)
+    }
+
+    historyRects.push(rects)
+  }
+
+  // Draw partial linearizations
+  const illegalLast = coreHistory.map((partition) => {
+    return partition.PartialLinearizations.map(() => new Set())
+  })
+  const largestIllegal = coreHistory.map(() => {
+    return {}
+  })
+  const largestIllegalLength = coreHistory.map(() => {
+    return {}
+  })
+  const partialLayers = []
+  const errorPoints = []
+  for (const [partitionIndex, partition] of coreHistory.entries()) {
+    const l = []
+    partialLayers.push(l)
+    for (const [linIndex, lin] of partition.PartialLinearizations.entries()) {
+      const g = svgadd(svg, 'g')
+      l.push(g)
+      let previousX = null
+      let previousY = null
+      let previousElement = null
+      const included = new Set()
+      for (const id of lin) {
+        const element = partition.History[id.Index]
+        const hereX = t0x + xPos[element.Start]
+        const x = previousX === null ? hereX : Math.max(hereX, previousX + EPSILON)
+        const y = PADDING + element.ClientId * (BOX_HEIGHT + BOX_SPACE) - LINE_BLEED
+        // Line from previous
+        if (previousElement !== null) {
+          svgadd(g, 'line', {
+            x1: previousX,
+            x2: x,
+            y1:
+              previousElement.ClientId >= element.ClientId
+                ? previousY
+                : previousY + BOX_HEIGHT + 2 * LINE_BLEED,
+            y2: previousElement.ClientId <= element.ClientId ? y : y + BOX_HEIGHT + 2 * LINE_BLEED,
+            class: 'linearization linearization-line',
+          })
+        }
+
+        // Current line
+        svgadd(g, 'line', {
+          x1: x,
+          x2: x,
+          y1: y,
+          y2: y + BOX_HEIGHT + 2 * LINE_BLEED,
+          class: 'linearization linearization-point',
+        })
+        previousX = x
+        previousY = y
+        previousElement = element
+        included.add(id.Index)
+      }
+
+      // Show possible but illegal next linearizations
+      // a history element is a possible next try
+      // if no other history element must be linearized earlier
+      // i.e. forall others, this.start < other.end
+      let minEnd = Infinity
+      for (const [index, element] of partition.History.entries()) {
+        if (!included.has(index)) {
+          minEnd = Math.min(minEnd, element.End)
+        }
+      }
+
+      for (const [index, element] of partition.History.entries()) {
+        if (!included.has(index) && element.Start < minEnd) {
+          const hereX = t0x + xPos[element.Start]
+          const x = previousX === null ? hereX : Math.max(hereX, previousX + EPSILON)
+          const y = PADDING + element.ClientId * (BOX_HEIGHT + BOX_SPACE) - LINE_BLEED
+          // Line from previous
+          svgadd(g, 'line', {
+            x1: previousX,
+            x2: x,
+            y1:
+              previousElement.ClientId >= element.ClientId
+                ? previousY
+                : previousY + BOX_HEIGHT + 2 * LINE_BLEED,
+            y2: previousElement.ClientId <= element.ClientId ? y : y + BOX_HEIGHT + 2 * LINE_BLEED,
+            class: 'linearization-invalid linearization-line',
+          })
+          // Current line
+          const point = svgadd(g, 'line', {
+            x1: x,
+            x2: x,
+            y1: y,
+            y2: y + BOX_HEIGHT + 2 * LINE_BLEED,
+            class: 'linearization-invalid linearization-point',
+          })
+          errorPoints.push({
+            x,
+            partition: partitionIndex,
+            index: lin.at(-1).Index, // NOTE not index
+            element: point,
+          })
+          illegalLast[partitionIndex][linIndex].add(index)
+          // eslint-disable-next-line max-depth
+          if (
+            !Object.hasOwn(largestIllegalLength[partitionIndex], index) ||
+            largestIllegalLength[partitionIndex][index] < lin.length
+          ) {
+            largestIllegalLength[partitionIndex][index] = lin.length
+            largestIllegal[partitionIndex][index] = linIndex
+          }
+        }
+      }
+    }
+  }
+
+  errorPoints.sort((a, b) => a.x - b.x)
+
+  // Attach targetRects
+  svgattach(svg, targetRects)
+
+  // Tooltip
+  // eslint-disable-next-line unicorn/prefer-dom-node-append
+  const tooltip = document.querySelector('#canvas').appendChild(document.createElement('div'))
+  tooltip.setAttribute('class', 'tooltip')
+
+  function handleMouseOver() {
+    if (!selected) {
+      const partition = Number.parseInt(this.dataset.partition, 10)
+      const index = Number.parseInt(this.dataset.index, 10)
+      highlight(partition, index)
+      tooltip.style.display = 'block'
+    }
+  }
+
+  function linearizationIndex(partition, index) {
+    // Show this linearization
+    if (partition >= coreHistory.length) {
+      // Annotation
+      return null
+    }
+
+    if (Object.hasOwn(coreHistory[partition].Largest, index)) {
+      return coreHistory[partition].Largest[index]
+    }
+
+    if (Object.hasOwn(largestIllegal[partition], index)) {
+      return largestIllegal[partition][index]
+    }
+
+    return null
+  }
+
+  function highlight(partition, index) {
+    // Hide all but this partition
+    for (const [i, layer] of historyLayers.entries()) {
+      if (i === partition) {
+        layer.classList.remove('hidden')
+      } else {
+        layer.classList.add('hidden')
+      }
+    }
+
+    // Hide all but the relevant linearization
+    for (const layer of partialLayers) {
+      for (const g of layer) {
+        g.classList.add('hidden')
+      }
+    }
+
+    // Show this linearization
+    const maxIndex = linearizationIndex(partition, index)
+    if (maxIndex !== null) {
+      partialLayers[partition][maxIndex].classList.remove('hidden')
+    }
+
+    updateJump()
+  }
+
+  let lastTooltip = [null, null, null, null, null]
+  function handleMouseMove(event_) {
+    // Keep tooltip static if selected
+    if (selected) {
+      return
+    }
+
+    const partition = Number.parseInt(this.dataset.partition, 10)
+    const index = Number.parseInt(this.dataset.index, 10)
+    const [sPartition, sIndex] = selectedIndex
+    const thisTooltip = [partition, index, selected, sPartition, sIndex]
+
+    if (!arrayEq(lastTooltip, thisTooltip)) {
+      // If selected, show info relevant to the selected linearization
+      const maxIndex = selected
+        ? linearizationIndex(sPartition, sIndex)
+        : linearizationIndex(partition, index)
+
+      const callTime = allData[partition].History[index].OriginalStart
+      const returnTime = allData[partition].History[index].OriginalEnd
+
+      let metadata = ''
+      if (partition < coreHistory.length) {
+        const m = allData[partition].History[index].Metadata
+        if (m !== '') {
+          metadata = m + '<br><br>'
+        }
+      }
+
+      if (partition >= coreHistory.length) {
+        // Annotation
+        const details = annotations[index].Details
+        tooltip.innerHTML = details.length === 0 ? '&langle;no details&rangle;' : details
+      } else if (selected && sPartition !== partition) {
+        tooltip.innerHTML =
+          metadata + 'Not part of selected partition.' + formatCallReturn(callTime, returnTime)
+      } else if (maxIndex === null) {
+        tooltip.innerHTML =
+          metadata +
+          (selected
+            ? 'Selected element is not part of any partial linearization.'
+            : 'Not part of any partial linearization.') +
+          formatCallReturn(callTime, returnTime)
+      } else {
+        const lin = coreHistory[partition].PartialLinearizations[maxIndex]
+        let previous = null
+        let current = null
+        let found = false
+        for (const element of lin) {
+          previous = current
+          current = element
+          if (current.Index === index) {
+            found = true
+            break
+          }
+        }
+
+        let message = metadata
+
+        if (found) {
+          // Part of linearization
+          if (previous !== null) {
+            message +=
+              '<strong>Previous state:</strong><br>' + previous.StateDescription + '<br><br>'
+          }
+
+          message +=
+            '<strong>New state:</strong><br>' +
+            current.StateDescription +
+            formatCallReturn(callTime, returnTime)
+        } else if (illegalLast[partition][maxIndex].has(index)) {
+          // Illegal next one
+          message +=
+            '<strong>Previous state:</strong><br>' +
+            lin.at(-1).StateDescription +
+            '<br><br><strong>New state:</strong><br>&langle;invalid op&rangle;' +
+            formatCallReturn(callTime, returnTime)
+        } else {
+          // Not part of this one
+          message +=
+            "Not part of selected element's partial linearization." +
+            formatCallReturn(callTime, returnTime)
+        }
+
+        tooltip.innerHTML = message
+      }
+
+      lastTooltip = thisTooltip
+    }
+
+    // Make sure tooltip doesn't overflow off the right side of the screen
+    const maxX =
+      document.documentElement.scrollLeft +
+      document.documentElement.clientWidth -
+      PADDING -
+      tooltip.getBoundingClientRect().width
+    tooltip.style.left = Math.min(event_.pageX + 20, maxX) + 'px'
+    tooltip.style.top = event_.pageY + 20 + 'px'
+  }
+
+  function handleMouseOut() {
+    if (!selected) {
+      resetHighlight()
+      tooltip.style.display = 'none'
+      lastTooltip = [null, null, null, null, null]
+    }
+  }
+
+  function resetHighlight() {
+    // Show all layers
+    for (const layer of historyLayers) {
+      layer.classList.remove('hidden')
+    }
+
+    // Show longest linearizations, which are first
+    for (const layers of partialLayers) {
+      for (const [i, l] of layers.entries()) {
+        if (i === 0) {
+          l.classList.remove('hidden')
+        } else {
+          l.classList.add('hidden')
+        }
+      }
+    }
+
+    updateJump()
+  }
+
+  // Store jump click handler so we can remove it before adding a new one
+  let jumpClickHandler = null
+
+  function updateJump() {
+    const jump = document.querySelector('#jump-link')
+    // Find first non-hidden point
+    // feels a little hacky, but it works
+    const point = errorPoints.find((pt) => !pt.element.parentElement.classList.contains('hidden'))
+
+    // Remove any existing event listener
+    if (jumpClickHandler) {
+      jump.removeEventListener('click', jumpClickHandler)
+      jumpClickHandler = null
+    }
+
+    if (point) {
+      jump.classList.remove('inactive')
+      jumpClickHandler = () => {
+        point.element.scrollIntoView({behavior: 'smooth', inline: 'center', block: 'center'})
+        if (!selected) {
+          select(point.partition, point.index)
+        }
+      }
+
+      jump.addEventListener('click', jumpClickHandler)
+    } else {
+      jump.classList.add('inactive')
+    }
+  }
+
+  function handleClick(event_) {
+    const partition = Number.parseInt(this.dataset.partition, 10)
+    const index = Number.parseInt(this.dataset.index, 10)
+    if (selected) {
+      const [sPartition, sIndex] = selectedIndex
+      if (partition === sPartition && index === sIndex) {
+        deselect()
+        // Note: we're still displaying the tooltip, but once the user's mouse moves, it'll get updated
+        return
+      }
+
+      historyRects[sPartition][sIndex].classList.remove('selected')
+    }
+
+    select(partition, index)
+
+    tooltip.style.display = 'block'
+    // Set static tooltip position when selecting
+    const maxX =
+      document.documentElement.scrollLeft +
+      document.documentElement.clientWidth -
+      PADDING -
+      tooltip.getBoundingClientRect().width
+    tooltip.style.left = Math.min(event_.pageX + 20, maxX) + 'px'
+    tooltip.style.top = event_.pageY + 20 + 'px'
+  }
+
+  function handleBgClick() {
+    deselect()
+
+    tooltip.style.display = 'none'
+    lastTooltip = [null, null, null, null, null]
+  }
+
+  function select(partition, index) {
+    selected = true
+    selectedIndex = [partition, index]
+    highlight(partition, index)
+    historyRects[partition][index].classList.add('selected')
+  }
+
+  function deselect() {
+    if (!selected) {
+      return
+    }
+
+    selected = false
+    resetHighlight()
+    const [partition, index] = selectedIndex
+    historyRects[partition][index].classList.remove('selected')
+  }
+
+  handleMouseOut() // Initialize, same as mouse out
+}
+
+
+      const data = {"Partitions":[{"History":[{"ClientId":0,"Start":9100,"OriginalStart":"123292","End":9200,"OriginalEnd":"123500","Description":"LoadAndDelete(key_0) -\u003e 900103","Metadata":""},{"ClientId":0,"Start":9300,"OriginalStart":"123583","End":9400,"OriginalEnd":"123833","Description":"LoadOrStore(key_0, 5) -\u003e stored","Metadata":""},{"ClientId":0,"Start":9600,"OriginalStart":"123958","End":9700,"OriginalEnd":"124042","Description":"LoadOrStore(key_0, 6) -\u003e loaded 5","Metadata":""},{"ClientId":0,"Start":10200,"OriginalStart":"129333","End":10300,"OriginalEnd":"129583","Description":"LoadAndDelete(key_0) -\u003e 1100024","Metadata":""},{"ClientId":0,"Start":10800,"OriginalStart":"132042","End":10900,"OriginalEnd":"132208","Description":"Store(key_0, 25)","Metadata":""},{"ClientId":0,"Start":11000,"OriginalStart":"132333","End":11100,"OriginalEnd":"132417","Description":"Load(key_0) -\u003e 25","Metadata":""},{"ClientId":0,"Start":11900,"OriginalStart":"135833","End":12000,"OriginalEnd":"136167","Description":"LoadAndDelete(key_0) -\u003e 1400128","Metadata":""},{"ClientId":0,"Start":12500,"OriginalStart":"138958","End":12600,"OriginalEnd":"139083","Description":"Load(key_0) -\u003e 1400135","Metadata":""},{"ClientId":0,"Start":13100,"OriginalStart":"142500","End":13200,"OriginalEnd":"142625","Description":"LoadAndDelete(key_0) -\u003e nil","Metadata":""},{"ClientId":0,"Start":13300,"OriginalStart":"143000","End":13400,"OriginalEnd":"143292","Description":"Store(key_0, 60)","Metadata":""},{"ClientId":0,"Start":14500,"OriginalStart":"147250","End":14600,"OriginalEnd":"147417","Description":"LoadOrStore(key_0, 74) -\u003e loaded 1100087","Metadata":""},{"ClientId":0,"Start":14700,"OriginalStart":"148458","End":14800,"OriginalEnd":"148583","Description":"LoadOrStore(key_0, 78) -\u003e loaded 1100087","Metadata":""},{"ClientId":0,"Start":15100,"OriginalStart":"149792","End":15200,"OriginalEnd":"150000","Description":"LoadAndDelete(key_0) -\u003e 1100087","Metadata":""},{"ClientId":0,"Start":15900,"OriginalStart":"158250","End":16000,"OriginalEnd":"158417","Description":"Store(key_0, 96)","Metadata":""},{"ClientId":0,"Start":16100,"OriginalStart":"160042","End":16200,"OriginalEnd":"160208","Description":"Store(key_0, 102)","Metadata":""},{"ClientId":0,"Start":16500,"OriginalStart":"162167","End":16600,"OriginalEnd":"162417","Description":"LoadAndDelete(key_0) -\u003e 100014","Metadata":""},{"ClientId":0,"Start":16700,"OriginalStart":"162542","End":16800,"OriginalEnd":"162708","Description":"Load(key_0) -\u003e nil","Metadata":""},{"ClientId":0,"Start":16900,"OriginalStart":"163667","End":17000,"OriginalEnd":"163958","Description":"LoadOrStore(key_0, 112) -\u003e stored","Metadata":""},{"ClientId":0,"Start":36400,"OriginalStart":"805208","End":36500,"OriginalEnd":"805500","Description":"Store(key_0, 143)","Metadata":""},{"ClientId":0,"Start":49400,"OriginalStart":"1322083","End":49600,"OriginalEnd":"1322292","Description":"Load(key_0) -\u003e nil","Metadata":""},{"ClientId":0,"Start":50000,"OriginalStart":"1323792","End":50200,"OriginalEnd":"1324167","Description":"LoadOrStore(key_0, 166) -\u003e stored","Metadata":""},{"ClientId":0,"Start":50400,"OriginalStart":"1324292","End":50500,"OriginalEnd":"1324417","Description":"LoadOrStore(key_0, 167) -\u003e loaded 500159","Metadata":""},{"ClientId":0,"Start":50800,"OriginalStart":"1325625","End":50900,"OriginalEnd":"1325917","Description":"LoadOrStore(key_0, 172) -\u003e stored","Metadata":""},{"ClientId":0,"Start":51000,"OriginalStart":"1326500","End":51100,"OriginalEnd":"1326667","Description":"Store(key_0, 175)","Metadata":""},{"ClientId":0,"Start":52000,"OriginalStart":"1328708","End":52100,"OriginalEnd":"1328917","Description":"Store(key_0, 182)","Metadata":""},{"ClientId":0,"Start":52200,"OriginalStart":"1329000","End":52300,"OriginalEnd":"1329167","Description":"Store(key_0, 183)","Metadata":""},{"ClientId":0,"Start":52400,"OriginalStart":"1329500","End":52500,"OriginalEnd":"1329708","Description":"LoadOrStore(key_0, 185) -\u003e loaded 183","Metadata":""},{"ClientId":0,"Start":53500,"OriginalStart":"1333625","End":53600,"OriginalEnd":"1333708","Description":"Load(key_0) -\u003e nil","Metadata":""},{"ClientId":1,"Start":16300,"OriginalStart":"160667","End":16400,"OriginalEnd":"160875","Description":"Store(key_0, 100014)","Metadata":""},{"ClientId":1,"Start":18200,"OriginalStart":"169667","End":18300,"OriginalEnd":"169792","Description":"LoadOrStore(key_0, 100019) -\u003e loaded 1200106","Metadata":""},{"ClientId":1,"Start":18400,"OriginalStart":"170250","End":18500,"OriginalEnd":"170417","Description":"LoadOrStore(key_0, 100021) -\u003e loaded 1200106","Metadata":""},{"ClientId":1,"Start":34500,"OriginalStart":"654542","End":34600,"OriginalEnd":"655542","Description":"Store(key_0, 100026)","Metadata":""},{"ClientId":1,"Start":35900,"OriginalStart":"800875","End":36000,"OriginalEnd":"801125","Description":"Load(key_0) -\u003e nil","Metadata":""},{"ClientId":1,"Start":39000,"OriginalStart":"902750","End":39100,"OriginalEnd":"902833","Description":"LoadOrStore(key_0, 100055) -\u003e loaded 1100193","Metadata":""},{"ClientId":1,"Start":39200,"OriginalStart":"904167","End":39300,"OriginalEnd":"904375","Description":"Load(key_0) -\u003e 1100193","Metadata":""},{"ClientId":1,"Start":39400,"OriginalStart":"906083","End":39500,"OriginalEnd":"906167","Description":"LoadOrStore(key_0, 100063) -\u003e loaded 1100193","Metadata":""},{"ClientId":1,"Start":39700,"OriginalStart":"907750","End":39800,"OriginalEnd":"907958","Description":"Store(key_0, 100069)","Metadata":""},{"ClientId":1,"Start":39900,"OriginalStart":"908958","End":40000,"OriginalEnd":"909083","Description":"LoadOrStore(key_0, 100074) -\u003e loaded 100069","Metadata":""},{"ClientId":1,"Start":46900,"OriginalStart":"1303583","End":47100,"OriginalEnd":"1303875","Description":"Store(key_0, 100098)","Metadata":""},{"ClientId":1,"Start":54100,"OriginalStart":"1336500","End":54200,"OriginalEnd":"1336917","Description":"LoadOrStore(key_0, 100115) -\u003e stored","Metadata":""},{"ClientId":1,"Start":55100,"OriginalStart":"1339083","End":55200,"OriginalEnd":"1339250","Description":"Store(key_0, 100121)","Metadata":""},{"ClientId":1,"Start":55900,"OriginalStart":"1340875","End":56000,"OriginalEnd":"1341000","Description":"LoadAndDelete(key_0) -\u003e nil","Metadata":""},{"ClientId":1,"Start":58800,"OriginalStart":"1351333","End":58900,"OriginalEnd":"1351500","Description":"LoadAndDelete(key_0) -\u003e nil","Metadata":""},{"ClientId":1,"Start":59100,"OriginalStart":"1352250","End":59200,"OriginalEnd":"1352333","Description":"LoadAndDelete(key_0) -\u003e nil","Metadata":""},{"ClientId":1,"Start":59400,"OriginalStart":"1352708","End":59500,"OriginalEnd":"1353042","Description":"LoadAndDelete(key_0) -\u003e 600160","Metadata":""},{"ClientId":1,"Start":60300,"OriginalStart":"1355875","End":60400,"OriginalEnd":"1355958","Description":"Load(key_0) -\u003e nil","Metadata":""},{"ClientId":1,"Start":61200,"OriginalStart":"1358333","End":61300,"OriginalEnd":"1358417","Description":"LoadAndDelete(key_0) -\u003e nil","Metadata":""},{"ClientId":1,"Start":62200,"OriginalStart":"1366000","End":62300,"OriginalEnd":"1366208","Description":"LoadAndDelete(key_0) -\u003e 600190","Metadata":""},{"ClientId":1,"Start":62800,"OriginalStart":"1369583","End":62900,"OriginalEnd":"1369708","Description":"LoadOrStore(key_0, 100197) -\u003e loaded 1500152","Metadata":""},{"ClientId":1,"Start":63200,"OriginalStart":"1370208","End":63400,"OriginalEnd":"1370417","Description":"Store(key_0, 100199)","Metadata":""},{"ClientId":2,"Start":17600,"OriginalStart":"166542","End":17700,"OriginalEnd":"166708","Description":"LoadOrStore(key_0, 200002) -\u003e loaded 1200106","Metadata":""},{"ClientId":2,"Start":32300,"OriginalStart":"534833","End":32400,"OriginalEnd":"534917","Description":"LoadOrStore(key_0, 200018) -\u003e loaded 700091","Metadata":""},{"ClientId":2,"Start":32500,"OriginalStart":"535042","End":33000,"OriginalEnd":"536000","Description":"Store(key_0, 200019)","Metadata":""},{"ClientId":2,"Start":33100,"OriginalStart":"536167","End":33700,"OriginalEnd":"539250","Description":"Store(key_0, 200020)","Metadata":""},{"ClientId":2,"Start":40900,"OriginalStart":"1282208","End":44800,"OriginalEnd":"1297208","Description":"Store(key_0, 200038)","Metadata":""},{"ClientId":2,"Start":45500,"OriginalStart":"1300000","End":45800,"OriginalEnd":"1300625","Description":"Store(key_0, 200048)","Metadata":""},{"ClientId":2,"Start":47200,"OriginalStart":"1304042","End":47300,"OriginalEnd":"1304208","Description":"LoadOrStore(key_0, 200058) -\u003e loaded 100098","Metadata":""},{"ClientId":2,"Start":47400,"OriginalStart":"1304333","End":47500,"OriginalEnd":"1304500","Description":"Store(key_0, 200059)","Metadata":""},{"ClientId":2,"Start":48100,"OriginalStart":"1317833","End":48200,"OriginalEnd":"1317917","Description":"LoadAndDelete(key_0) -\u003e nil","Metadata":""},{"ClientId":2,"Start":48400,"OriginalStart":"1318958","End":48500,"OriginalEnd":"1319042","Description":"Load(key_0) -\u003e 900164","Metadata":""},{"ClientId":2,"Start":48800,"OriginalStart":"1321042","End":48900,"OriginalEnd":"1321167","Description":"Load(key_0) -\u003e 900164","Metadata":""},{"ClientId":2,"Start":49000,"OriginalStart":"1321292","End":49200,"OriginalEnd":"1321417","Description":"Load(key_0) -\u003e nil","Metadata":""},{"ClientId":2,"Start":49500,"OriginalStart":"1322125","End":49700,"OriginalEnd":"1322375","Description":"LoadAndDelete(key_0) -\u003e 500151","Metadata":""},{"ClientId":2,"Start":54300,"OriginalStart":"1337042","End":54400,"OriginalEnd":"1337125","Description":"Load(key_0) -\u003e 100115","Metadata":""},{"ClientId":2,"Start":54800,"OriginalStart":"1338125","End":55000,"OriginalEnd":"1338250","Description":"Load(key_0) -\u003e 1000175","Metadata":""},{"ClientId":2,"Start":55500,"OriginalStart":"1340208","End":55600,"OriginalEnd":"1340292","Description":"Load(key_0) -\u003e 100121","Metadata":""},{"ClientId":2,"Start":55700,"OriginalStart":"1340417","End":55800,"OriginalEnd":"1340708","Description":"LoadAndDelete(key_0) -\u003e 100121","Metadata":""},{"ClientId":2,"Start":56100,"OriginalStart":"1342042","End":56200,"OriginalEnd":"1342167","Description":"LoadAndDelete(key_0) -\u003e nil","Metadata":""},{"ClientId":2,"Start":56500,"OriginalStart":"1342833","End":56600,"OriginalEnd":"1343083","Description":"LoadOrStore(key_0, 200112) -\u003e stored","Metadata":""},{"ClientId":2,"Start":57100,"OriginalStart":"1346542","End":57300,"OriginalEnd":"1346792","Description":"LoadAndDelete(key_0) -\u003e 1500121","Metadata":""},{"ClientId":2,"Start":57500,"OriginalStart":"1347333","End":57600,"OriginalEnd":"1347625","Description":"LoadAndDelete(key_0) -\u003e 1000180","Metadata":""},{"ClientId":2,"Start":57800,"OriginalStart":"1347750","End":58100,"OriginalEnd":"1348625","Description":"Store(key_0, 200126)","Metadata":""},{"ClientId":2,"Start":60100,"OriginalStart":"1354750","End":60200,"OriginalEnd":"1354875","Description":"Load(key_0) -\u003e nil","Metadata":""},{"ClientId":2,"Start":60500,"OriginalStart":"1356208","End":60700,"OriginalEnd":"1356417","Description":"Store(key_0, 200148)","Metadata":""},{"ClientId":2,"Start":60800,"OriginalStart":"1356750","End":60900,"OriginalEnd":"1356917","Description":"Store(key_0, 200150)","Metadata":""},{"ClientId":2,"Start":61400,"OriginalStart":"1358583","End":61500,"OriginalEnd":"1358833","Description":"LoadOrStore(key_0, 200156) -\u003e stored","Metadata":""},{"ClientId":2,"Start":61800,"OriginalStart":"1360333","End":61900,"OriginalEnd":"1360458","Description":"Load(key_0) -\u003e 600183","Metadata":""},{"ClientId":2,"Start":62600,"OriginalStart":"1368875","End":62700,"OriginalEnd":"1369000","Description":"Load(key_0) -\u003e 1500152","Metadata":""},{"ClientId":2,"Start":63300,"OriginalStart":"1370250","End":63400,"OriginalEnd":"1370417","Description":"Store(key_0, 200192)","Metadata":""},{"ClientId":2,"Start":63500,"OriginalStart":"1370542","End":63600,"OriginalEnd":"1370875","Description":"LoadAndDelete(key_0) -\u003e 100199","Metadata":""},{"ClientId":2,"Start":63700,"OriginalStart":"1371333","End":63800,"OriginalEnd":"1371417","Description":"Load(key_0) -\u003e nil","Metadata":""},{"ClientId":3,"Start":600,"OriginalStart":"74750","End":700,"OriginalEnd":"75167","Description":"Store(key_0, 300003)","Metadata":""},{"ClientId":3,"Start":1200,"OriginalStart":"77583","End":1300,"OriginalEnd":"77667","Description":"Load(key_0) -\u003e nil","Metadata":""},{"ClientId":3,"Start":1800,"OriginalStart":"79375","End":1900,"OriginalEnd":"79458","Description":"LoadAndDelete(key_0) -\u003e nil","Metadata":""},{"ClientId":3,"Start":2600,"OriginalStart":"91917","End":2700,"OriginalEnd":"92125","Description":"Store(key_0, 300060)","Metadata":""},{"ClientId":3,"Start":2800,"OriginalStart":"93667","End":3000,"OriginalEnd":"93792","Description":"Load(key_0) -\u003e 300060","Metadata":""},{"ClientId":3,"Start":4400,"OriginalStart":"101167","End":4500,"OriginalEnd":"101333","Description":"LoadOrStore(key_0, 300084) -\u003e loaded 300060","Metadata":""},{"ClientId":3,"Start":4700,"OriginalStart":"101875","End":4900,"OriginalEnd":"102042","Description":"Store(key_0, 300086)","Metadata":""},{"ClientId":3,"Start":5200,"OriginalStart":"104208","End":5300,"OriginalEnd":"104500","Description":"LoadOrStore(key_0, 300094) -\u003e stored","Metadata":""},{"ClientId":3,"Start":19300,"OriginalStart":"174125","End":19400,"OriginalEnd":"174625","Description":"LoadOrStore(key_0, 300102) -\u003e stored","Metadata":""},{"ClientId":3,"Start":19500,"OriginalStart":"175250","End":19600,"OriginalEnd":"175333","Description":"Load(key_0) -\u003e 300102","Metadata":""},{"ClientId":3,"Start":20100,"OriginalStart":"177083","End":20200,"OriginalEnd":"177500","Description":"LoadOrStore(key_0, 300111) -\u003e stored","Metadata":""},{"ClientId":3,"Start":22700,"OriginalStart":"194250","End":22800,"OriginalEnd":"194458","Description":"Store(key_0, 300154)","Metadata":""},{"ClientId":3,"Start":22900,"OriginalStart":"195417","End":23000,"OriginalEnd":"195625","Description":"Store(key_0, 300158)","Metadata":""},{"ClientId":3,"Start":37500,"OriginalStart":"886292","End":37600,"OriginalEnd":"886458","Description":"Load(key_0) -\u003e nil","Metadata":""},{"ClientId":4,"Start":12900,"OriginalStart":"140458","End":13000,"OriginalEnd":"140583","Description":"LoadAndDelete(key_0) -\u003e nil","Metadata":""},{"ClientId":4,"Start":13800,"OriginalStart":"144958","End":13900,"OriginalEnd":"145083","Description":"LoadAndDelete(key_0) -\u003e nil","Metadata":""},{"ClientId":4,"Start":21900,"OriginalStart":"189833","End":22000,"OriginalEnd":"190167","Description":"LoadOrStore(key_0, 400055) -\u003e stored","Metadata":""},{"ClientId":4,"Start":23300,"OriginalStart":"197792","End":23400,"OriginalEnd":"198000","Description":"Store(key_0, 400074)","Metadata":""},{"ClientId":4,"Start":26100,"OriginalStart":"212792","End":26300,"OriginalEnd":"213875","Description":"Store(key_0, 400110)","Metadata":""},{"ClientId":4,"Start":26400,"OriginalStart":"214042","End":26600,"OriginalEnd":"214208","Description":"Store(key_0, 400111)","Metadata":""},{"ClientId":4,"Start":27200,"OriginalStart":"215458","End":27400,"OriginalEnd":"215625","Description":"Load(key_0) -\u003e 800079","Metadata":""},{"ClientId":4,"Start":33800,"OriginalStart":"540000","End":34000,"OriginalEnd":"541625","Description":"Store(key_0, 400128)","Metadata":""},{"ClientId":4,"Start":34700,"OriginalStart":"749250","End":34800,"OriginalEnd":"750083","Description":"Load(key_0) -\u003e 100026","Metadata":""},{"ClientId":4,"Start":38900,"OriginalStart":"901625","End":40800,"OriginalEnd":"1279667","Description":"LoadAndDelete(key_0) -\u003e nil","Metadata":""},{"ClientId":4,"Start":41000,"OriginalStart":"1282375","End":41100,"OriginalEnd":"1282958","Description":"Store(key_0, 400149)","Metadata":""},{"ClientId":4,"Start":42800,"OriginalStart":"1291292","End":42900,"OriginalEnd":"1291458","Description":"LoadAndDelete(key_0) -\u003e 1000125","Metadata":""},{"ClientId":4,"Start":43000,"OriginalStart":"1291583","End":43100,"OriginalEnd":"1291667","Description":"LoadAndDelete(key_0) -\u003e nil","Metadata":""},{"ClientId":4,"Start":43800,"OriginalStart":"1294125","End":43900,"OriginalEnd":"1294333","Description":"LoadAndDelete(key_0) -\u003e 600087","Metadata":""},{"ClientId":4,"Start":45600,"OriginalStart":"1300042","End":45700,"OriginalEnd":"1300167","Description":"LoadAndDelete(key_0) -\u003e nil","Metadata":""},{"ClientId":4,"Start":45800,"OriginalStart":"1300625","End":45900,"OriginalEnd":"1300917","Description":"LoadAndDelete(key_0) -\u003e 200048","Metadata":""},{"ClientId":5,"Start":15500,"OriginalStart":"154542","End":15600,"OriginalEnd":"154708","Description":"Load(key_0) -\u003e nil","Metadata":""},{"ClientId":5,"Start":15700,"OriginalStart":"155208","End":15800,"OriginalEnd":"156167","Description":"LoadOrStore(key_0, 500007) -\u003e stored","Metadata":""},{"ClientId":5,"Start":17100,"OriginalStart":"164000","End":17200,"OriginalEnd":"164250","Description":"Store(key_0, 500031)","Metadata":""},{"ClientId":5,"Start":17300,"OriginalStart":"165625","End":17400,"OriginalEnd":"165833","Description":"Store(key_0, 500036)","Metadata":""},{"ClientId":5,"Start":17800,"OriginalStart":"166875","End":17900,"OriginalEnd":"167000","Description":"LoadOrStore(key_0, 500040) -\u003e loaded 1200106","Metadata":""},{"ClientId":5,"Start":18000,"OriginalStart":"168292","End":18100,"OriginalEnd":"168458","Description":"LoadOrStore(key_0, 500044) -\u003e loaded 1200106","Metadata":""},{"ClientId":5,"Start":36700,"OriginalStart":"807000","End":36800,"OriginalEnd":"807833","Description":"Store(key_0, 500054)","Metadata":""},{"ClientId":5,"Start":36900,"OriginalStart":"808458","End":37200,"OriginalEnd":"811250","Description":"LoadAndDelete(key_0) -\u003e 500054","Metadata":""},{"ClientId":5,"Start":41200,"OriginalStart":"1284458","End":41400,"OriginalEnd":"1284625","Description":"Store(key_0, 500086)","Metadata":""},{"ClientId":5,"Start":41500,"OriginalStart":"1284792","End":41700,"OriginalEnd":"1285125","Description":"LoadAndDelete(key_0) -\u003e 500086","Metadata":""},{"ClientId":5,"Start":41800,"OriginalStart":"1287167","End":41900,"OriginalEnd":"1287333","Description":"LoadAndDelete(key_0) -\u003e nil","Metadata":""},{"ClientId":5,"Start":42000,"OriginalStart":"1288042","End":42100,"OriginalEnd":"1288125","Description":"LoadAndDelete(key_0) -\u003e nil","Metadata":""},{"ClientId":5,"Start":43200,"OriginalStart":"1291750","End":43300,"OriginalEnd":"1291875","Description":"Load(key_0) -\u003e nil","Metadata":""},{"ClientId":5,"Start":44200,"OriginalStart":"1295000","End":44500,"OriginalEnd":"1295292","Description":"Store(key_0, 500118)","Metadata":""},{"ClientId":5,"Start":45000,"OriginalStart":"1297958","End":45200,"OriginalEnd":"1298542","Description":"LoadOrStore(key_0, 500126) -\u003e stored","Metadata":""},{"ClientId":5,"Start":45300,"OriginalStart":"1298667","End":45400,"OriginalEnd":"1299292","Description":"LoadAndDelete(key_0) -\u003e 500126","Metadata":""},{"ClientId":5,"Start":46000,"OriginalStart":"1301292","End":46200,"OriginalEnd":"1301750","Description":"Store(key_0, 500133)","Metadata":""},{"ClientId":5,"Start":46400,"OriginalStart":"1301875","End":46500,"OriginalEnd":"1302042","Description":"LoadAndDelete(key_0) -\u003e 500133","Metadata":""},{"ClientId":5,"Start":46600,"OriginalStart":"1302500","End":46700,"OriginalEnd":"1302875","Description":"Store(key_0, 500136)","Metadata":""},{"ClientId":5,"Start":49100,"OriginalStart":"1321375","End":49300,"OriginalEnd":"1321667","Description":"Store(key_0, 500151)","Metadata":""},{"ClientId":5,"Start":49800,"OriginalStart":"1323542","End":49900,"OriginalEnd":"1323667","Description":"Load(key_0) -\u003e nil","Metadata":""},{"ClientId":5,"Start":50100,"OriginalStart":"1324000","End":50300,"OriginalEnd":"1324250","Description":"Store(key_0, 500159)","Metadata":""},{"ClientId":5,"Start":56900,"OriginalStart":"1346333","End":57000,"OriginalEnd":"1346500","Description":"LoadOrStore(key_0, 500185) -\u003e loaded 1500121","Metadata":""},{"ClientId":5,"Start":57700,"OriginalStart":"1347667","End":57900,"OriginalEnd":"1347792","Description":"LoadAndDelete(key_0) -\u003e nil","Metadata":""},{"ClientId":5,"Start":59600,"OriginalStart":"1353083","End":59700,"OriginalEnd":"1353208","Description":"LoadAndDelete(key_0) -\u003e nil","Metadata":""},{"ClientId":5,"Start":59800,"OriginalStart":"1353667","End":59900,"OriginalEnd":"1353917","Description":"LoadAndDelete(key_0) -\u003e nil","Metadata":""},{"ClientId":5,"Start":60000,"OriginalStart":"1354667","End":60100,"OriginalEnd":"1354750","Description":"LoadAndDelete(key_0) -\u003e nil","Metadata":""},{"ClientId":6,"Start":25300,"OriginalStart":"209958","End":25400,"OriginalEnd":"210125","Description":"LoadOrStore(key_0, 600004) -\u003e loaded 700063","Metadata":""},{"ClientId":6,"Start":25900,"OriginalStart":"211792","End":26000,"OriginalEnd":"211875","Description":"Load(key_0) -\u003e nil","Metadata":""},{"ClientId":6,"Start":26500,"OriginalStart":"214167","End":26700,"OriginalEnd":"214458","Description":"LoadAndDelete(key_0) -\u003e 400111","Metadata":""},{"ClientId":6,"Start":26900,"OriginalStart":"215292","End":27100,"OriginalEnd":"215417","Description":"Load(key_0) -\u003e 800079","Metadata":""},{"ClientId":6,"Start":27300,"OriginalStart":"215583","End":27600,"OriginalEnd":"215833","Description":"LoadAndDelete(key_0) -\u003e 800079","Metadata":""},{"ClientId":6,"Start":27700,"OriginalStart":"215917","End":27900,"OriginalEnd":"216125","Description":"LoadOrStore(key_0, 600022) -\u003e loaded 1000092","Metadata":""},{"ClientId":6,"Start":34300,"OriginalStart":"547208","End":34400,"OriginalEnd":"547417","Description":"LoadAndDelete(key_0) -\u003e 400128","Metadata":""},{"ClientId":6,"Start":40400,"OriginalStart":"1045917","End":40500,"OriginalEnd":"1046042","Description":"Load(key_0) -\u003e nil","Metadata":""},{"ClientId":6,"Start":41300,"OriginalStart":"1284500","End":41400,"OriginalEnd":"1284625","Description":"LoadOrStore(key_0, 600060) -\u003e loaded 400149","Metadata":""},{"ClientId":6,"Start":41600,"OriginalStart":"1285000","End":41700,"OriginalEnd":"1285125","Description":"Load(key_0) -\u003e nil","Metadata":""},{"ClientId":6,"Start":42200,"OriginalStart":"1288500","End":42300,"OriginalEnd":"1288625","Description":"LoadAndDelete(key_0) -\u003e nil","Metadata":""},{"ClientId":6,"Start":43400,"OriginalStart":"1292333","End":43500,"OriginalEnd":"1292958","Description":"Store(key_0, 600087)","Metadata":""},{"ClientId":6,"Start":43600,"OriginalStart":"1293083","End":43700,"OriginalEnd":"1293250","Description":"LoadOrStore(key_0, 600088) -\u003e loaded 600087","Metadata":""},{"ClientId":6,"Start":44000,"OriginalStart":"1294583","End":44100,"OriginalEnd":"1294750","Description":"Load(key_0) -\u003e nil","Metadata":""},{"ClientId":6,"Start":44300,"OriginalStart":"1295083","End":44400,"OriginalEnd":"1295208","Description":"LoadAndDelete(key_0) -\u003e nil","Metadata":""},{"ClientId":6,"Start":44600,"OriginalStart":"1295333","End":44700,"OriginalEnd":"1295583","Description":"Store(key_0, 600096)","Metadata":""},{"ClientId":6,"Start":44900,"OriginalStart":"1297792","End":45100,"OriginalEnd":"1298042","Description":"LoadAndDelete(key_0) -\u003e 200038","Metadata":""},{"ClientId":6,"Start":46100,"OriginalStart":"1301625","End":46300,"OriginalEnd":"1301792","Description":"Load(key_0) -\u003e 500133","Metadata":""},{"ClientId":6,"Start":47800,"OriginalStart":"1316875","End":47900,"OriginalEnd":"1317083","Description":"LoadAndDelete(key_0) -\u003e 900158","Metadata":""},{"ClientId":6,"Start":48900,"OriginalStart":"1321167","End":49200,"OriginalEnd":"1321417","Description":"LoadAndDelete(key_0) -\u003e 900164","Metadata":""},{"ClientId":6,"Start":58500,"OriginalStart":"1351000","End":58700,"OriginalEnd":"1351250","Description":"LoadAndDelete(key_0) -\u003e 1000183","Metadata":""},{"ClientId":6,"Start":59000,"OriginalStart":"1352167","End":59300,"OriginalEnd":"1352542","Description":"LoadOrStore(key_0, 600160) -\u003e stored","Metadata":""},{"ClientId":6,"Start":60500,"OriginalStart":"1356208","End":60600,"OriginalEnd":"1356292","Description":"Load(key_0) -\u003e nil","Metadata":""},{"ClientId":6,"Start":60900,"OriginalStart":"1356917","End":61000,"OriginalEnd":"1357125","Description":"LoadAndDelete(key_0) -\u003e 200150","Metadata":""},{"ClientId":6,"Start":61100,"OriginalStart":"1358125","End":61200,"OriginalEnd":"1358333","Description":"Load(key_0) -\u003e nil","Metadata":""},{"ClientId":6,"Start":61600,"OriginalStart":"1359708","End":61700,"OriginalEnd":"1359875","Description":"Store(key_0, 600183)","Metadata":""},{"ClientId":6,"Start":62000,"OriginalStart":"1361667","End":62100,"OriginalEnd":"1361792","Description":"Store(key_0, 600190)","Metadata":""},{"ClientId":7,"Start":23100,"OriginalStart":"197583","End":23200,"OriginalEnd":"197750","Description":"LoadOrStore(key_0, 700034) -\u003e loaded 300158","Metadata":""},{"ClientId":7,"Start":23500,"OriginalStart":"200958","End":23600,"OriginalEnd":"201167","Description":"Store(key_0, 700043)","Metadata":""},{"ClientId":7,"Start":23800,"OriginalStart":"202667","End":23900,"OriginalEnd":"202792","Description":"LoadOrStore(key_0, 700048) -\u003e loaded 700043","Metadata":""},{"ClientId":7,"Start":24500,"OriginalStart":"205458","End":24600,"OriginalEnd":"205583","Description":"Load(key_0) -\u003e nil","Metadata":""},{"ClientId":7,"Start":24700,"OriginalStart":"207167","End":24800,"OriginalEnd":"207417","Description":"Store(key_0, 700063)","Metadata":""},{"ClientId":7,"Start":25100,"OriginalStart":"208833","End":25200,"OriginalEnd":"209042","Description":"LoadOrStore(key_0, 700068) -\u003e loaded 700063","Metadata":""},{"ClientId":7,"Start":30900,"OriginalStart":"528458","End":31000,"OriginalEnd":"528708","Description":"LoadAndDelete(key_0) -\u003e 1300080","Metadata":""},{"ClientId":7,"Start":31200,"OriginalStart":"531833","End":31400,"OriginalEnd":"532083","Description":"LoadAndDelete(key_0) -\u003e 1100155","Metadata":""},{"ClientId":7,"Start":31500,"OriginalStart":"532917","End":31600,"OriginalEnd":"533333","Description":"Store(key_0, 700086)","Metadata":""},{"ClientId":7,"Start":31700,"OriginalStart":"533667","End":31800,"OriginalEnd":"533708","Description":"Load(key_0) -\u003e 700086","Metadata":""},{"ClientId":7,"Start":32000,"OriginalStart":"534458","End":32200,"OriginalEnd":"534583","Description":"Store(key_0, 700091)","Metadata":""},{"ClientId":7,"Start":32600,"OriginalStart":"535333","End":32700,"OriginalEnd":"535417","Description":"Load(key_0) -\u003e 700091","Metadata":""},{"ClientId":7,"Start":33200,"OriginalStart":"536833","End":33300,"OriginalEnd":"536958","Description":"LoadAndDelete(key_0) -\u003e nil","Metadata":""},{"ClientId":7,"Start":33900,"OriginalStart":"541500","End":34100,"OriginalEnd":"541708","Description":"Load(key_0) -\u003e 400128","Metadata":""},{"ClientId":7,"Start":40100,"OriginalStart":"921625","End":40200,"OriginalEnd":"921875","Description":"Load(key_0) -\u003e 100069","Metadata":""},{"ClientId":7,"Start":40600,"OriginalStart":"1279292","End":40700,"OriginalEnd":"1279375","Description":"Load(key_0) -\u003e nil","Metadata":""},{"ClientId":7,"Start":46300,"OriginalStart":"1301792","End":46400,"OriginalEnd":"1301875","Description":"Load(key_0) -\u003e 500133","Metadata":""},{"ClientId":7,"Start":46800,"OriginalStart":"1303417","End":47000,"OriginalEnd":"1303625","Description":"LoadAndDelete(key_0) -\u003e 500136","Metadata":""},{"ClientId":7,"Start":50600,"OriginalStart":"1324708","End":50700,"OriginalEnd":"1324958","Description":"LoadAndDelete(key_0) -\u003e 500159","Metadata":""},{"ClientId":7,"Start":52600,"OriginalStart":"1329792","End":52800,"OriginalEnd":"1329958","Description":"Load(key_0) -\u003e 900190","Metadata":""},{"ClientId":7,"Start":52900,"OriginalStart":"1331833","End":53000,"OriginalEnd":"1332083","Description":"LoadAndDelete(key_0) -\u003e 900190","Metadata":""},{"ClientId":7,"Start":53300,"OriginalStart":"1332833","End":53400,"OriginalEnd":"1332875","Description":"Load(key_0) -\u003e nil","Metadata":""},{"ClientId":7,"Start":53900,"OriginalStart":"1335000","End":54000,"OriginalEnd":"1335125","Description":"Load(key_0) -\u003e nil","Metadata":""},{"ClientId":8,"Start":22300,"OriginalStart":"191625","End":22400,"OriginalEnd":"191792","Description":"Store(key_0, 800010)","Metadata":""},{"ClientId":8,"Start":22500,"OriginalStart":"193250","End":22600,"OriginalEnd":"193458","Description":"LoadOrStore(key_0, 800016) -\u003e loaded 800010","Metadata":""},{"ClientId":8,"Start":25500,"OriginalStart":"210792","End":25600,"OriginalEnd":"211000","Description":"LoadAndDelete(key_0) -\u003e 700063","Metadata":""},{"ClientId":8,"Start":26200,"OriginalStart":"213583","End":26400,"OriginalEnd":"214042","Description":"LoadOrStore(key_0, 800075) -\u003e loaded 400110","Metadata":""},{"ClientId":8,"Start":26800,"OriginalStart":"215125","End":27000,"OriginalEnd":"215375","Description":"Store(key_0, 800079)","Metadata":""},{"ClientId":8,"Start":28300,"OriginalStart":"455042","End":28400,"OriginalEnd":"455917","Description":"Store(key_0, 800092)","Metadata":""},{"ClientId":8,"Start":28700,"OriginalStart":"509167","End":28800,"OriginalEnd":"509292","Description":"Store(key_0, 800104)","Metadata":""},{"ClientId":8,"Start":29500,"OriginalStart":"513208","End":29600,"OriginalEnd":"513375","Description":"Store(key_0, 800118)","Metadata":""},{"ClientId":8,"Start":29900,"OriginalStart":"518292","End":30000,"OriginalEnd":"518458","Description":"LoadAndDelete(key_0) -\u003e 800118","Metadata":""},{"ClientId":8,"Start":31900,"OriginalStart":"534417","End":32100,"OriginalEnd":"534542","Description":"Store(key_0, 800185)","Metadata":""},{"ClientId":9,"Start":1600,"OriginalStart":"78708","End":1700,"OriginalEnd":"79042","Description":"Load(key_0) -\u003e nil","Metadata":""},{"ClientId":9,"Start":3600,"OriginalStart":"97250","End":3700,"OriginalEnd":"97375","Description":"Load(key_0) -\u003e 300060","Metadata":""},{"ClientId":9,"Start":3800,"OriginalStart":"99333","End":3900,"OriginalEnd":"99417","Description":"Load(key_0) -\u003e 300060","Metadata":""},{"ClientId":9,"Start":4000,"OriginalStart":"100167","End":4100,"OriginalEnd":"100333","Description":"Load(key_0) -\u003e 300060","Metadata":""},{"ClientId":9,"Start":4600,"OriginalStart":"101792","End":4800,"OriginalEnd":"101917","Description":"LoadOrStore(key_0, 900048) -\u003e loaded 300060","Metadata":""},{"ClientId":9,"Start":5000,"OriginalStart":"103667","End":5100,"OriginalEnd":"103917","Description":"LoadAndDelete(key_0) -\u003e 300086","Metadata":""},{"ClientId":9,"Start":6600,"OriginalStart":"110208","End":6700,"OriginalEnd":"110375","Description":"LoadOrStore(key_0, 900073) -\u003e loaded 1400058","Metadata":""},{"ClientId":9,"Start":7000,"OriginalStart":"112500","End":7300,"OriginalEnd":"112875","Description":"LoadOrStore(key_0, 900080) -\u003e stored","Metadata":""},{"ClientId":9,"Start":8100,"OriginalStart":"118542","End":8200,"OriginalEnd":"118667","Description":"LoadOrStore(key_0, 900096) -\u003e loaded 1400079","Metadata":""},{"ClientId":9,"Start":8500,"OriginalStart":"119042","End":8600,"OriginalEnd":"119417","Description":"LoadAndDelete(key_0) -\u003e 1400081","Metadata":""},{"ClientId":9,"Start":8700,"OriginalStart":"120958","End":8800,"OriginalEnd":"121292","Description":"LoadOrStore(key_0, 900103) -\u003e stored","Metadata":""},{"ClientId":9,"Start":8900,"OriginalStart":"122958","End":9000,"OriginalEnd":"123083","Description":"LoadOrStore(key_0, 900108) -\u003e loaded 900103","Metadata":""},{"ClientId":9,"Start":38300,"OriginalStart":"895625","End":38400,"OriginalEnd":"895875","Description":"Load(key_0) -\u003e 1100193","Metadata":""},{"ClientId":9,"Start":38700,"OriginalStart":"900708","End":38800,"OriginalEnd":"900917","Description":"LoadOrStore(key_0, 900137) -\u003e loaded 1100193","Metadata":""},{"ClientId":9,"Start":39600,"OriginalStart":"906375","End":40300,"OriginalEnd":"1044042","Description":"LoadAndDelete(key_0) -\u003e 100069","Metadata":""},{"ClientId":9,"Start":47600,"OriginalStart":"1308333","End":47700,"OriginalEnd":"1308500","Description":"Store(key_0, 900158)","Metadata":""},{"ClientId":9,"Start":48000,"OriginalStart":"1317792","End":48300,"OriginalEnd":"1318083","Description":"Store(key_0, 900164)","Metadata":""},{"ClientId":9,"Start":48600,"OriginalStart":"1320042","End":48700,"OriginalEnd":"1320167","Description":"LoadOrStore(key_0, 900171) -\u003e loaded 900164","Metadata":""},{"ClientId":9,"Start":51200,"OriginalStart":"1327208","End":51300,"OriginalEnd":"1327458","Description":"Store(key_0, 900183)","Metadata":""},{"ClientId":9,"Start":51600,"OriginalStart":"1328208","End":51800,"OriginalEnd":"1328500","Description":"LoadOrStore(key_0, 900186) -\u003e stored","Metadata":""},{"ClientId":9,"Start":52500,"OriginalStart":"1329708","End":52700,"OriginalEnd":"1329875","Description":"Store(key_0, 900190)","Metadata":""},{"ClientId":10,"Start":19100,"OriginalStart":"173917","End":19200,"OriginalEnd":"174083","Description":"Load(key_0) -\u003e nil","Metadata":""},{"ClientId":10,"Start":19700,"OriginalStart":"175875","End":19800,"OriginalEnd":"176083","Description":"Store(key_0, 1000014)","Metadata":""},{"ClientId":10,"Start":19900,"OriginalStart":"176333","End":20000,"OriginalEnd":"176583","Description":"LoadAndDelete(key_0) -\u003e 1000014","Metadata":""},{"ClientId":10,"Start":20300,"OriginalStart":"178167","End":20400,"OriginalEnd":"178250","Description":"LoadOrStore(key_0, 1000021) -\u003e loaded 300111","Metadata":""},{"ClientId":10,"Start":20700,"OriginalStart":"180750","End":20800,"OriginalEnd":"180833","Description":"LoadAndDelete(key_0) -\u003e nil","Metadata":""},{"ClientId":10,"Start":21300,"OriginalStart":"183458","End":21400,"OriginalEnd":"183542","Description":"LoadAndDelete(key_0) -\u003e nil","Metadata":""},{"ClientId":10,"Start":21500,"OriginalStart":"185417","End":21600,"OriginalEnd":"185542","Description":"Load(key_0) -\u003e nil","Metadata":""},{"ClientId":10,"Start":21700,"OriginalStart":"188750","End":21800,"OriginalEnd":"188875","Description":"LoadAndDelete(key_0) -\u003e nil","Metadata":""},{"ClientId":10,"Start":22100,"OriginalStart":"190583","End":22200,"OriginalEnd":"190750","Description":"LoadOrStore(key_0, 1000059) -\u003e loaded 400055","Metadata":""},{"ClientId":10,"Start":25700,"OriginalStart":"211125","End":25800,"OriginalEnd":"211208","Description":"Load(key_0) -\u003e nil","Metadata":""},{"ClientId":10,"Start":27500,"OriginalStart":"215792","End":27800,"OriginalEnd":"216042","Description":"Store(key_0, 1000092)","Metadata":""},{"ClientId":10,"Start":36300,"OriginalStart":"805125","End":36600,"OriginalEnd":"806333","Description":"LoadAndDelete(key_0) -\u003e 143","Metadata":""},{"ClientId":10,"Start":38500,"OriginalStart":"896625","End":38600,"OriginalEnd":"897542","Description":"LoadOrStore(key_0, 1000114) -\u003e loaded 1100193","Metadata":""},{"ClientId":10,"Start":42400,"OriginalStart":"1289042","End":42500,"OriginalEnd":"1289250","Description":"LoadOrStore(key_0, 1000125) -\u003e stored","Metadata":""},{"ClientId":10,"Start":42600,"OriginalStart":"1290208","End":42700,"OriginalEnd":"1290333","Description":"LoadOrStore(key_0, 1000129) -\u003e loaded 1000125","Metadata":""},{"ClientId":10,"Start":54500,"OriginalStart":"1337708","End":54600,"OriginalEnd":"1337833","Description":"Store(key_0, 1000174)","Metadata":""},{"ClientId":10,"Start":54700,"OriginalStart":"1338000","End":54900,"OriginalEnd":"1338167","Description":"Store(key_0, 1000175)","Metadata":""},{"ClientId":10,"Start":57200,"OriginalStart":"1346625","End":57400,"OriginalEnd":"1346958","Description":"LoadOrStore(key_0, 1000180) -\u003e stored","Metadata":""},{"ClientId":10,"Start":58400,"OriginalStart":"1350917","End":58600,"OriginalEnd":"1351083","Description":"Store(key_0, 1000183)","Metadata":""},{"ClientId":11,"Start":9500,"OriginalStart":"123917","End":9800,"OriginalEnd":"124208","Description":"LoadAndDelete(key_0) -\u003e 5","Metadata":""},{"ClientId":11,"Start":9900,"OriginalStart":"126333","End":10000,"OriginalEnd":"126833","Description":"Store(key_0, 1100024)","Metadata":""},{"ClientId":11,"Start":11200,"OriginalStart":"132833","End":11400,"OriginalEnd":"133583","Description":"Store(key_0, 1100043)","Metadata":""},{"ClientId":11,"Start":12700,"OriginalStart":"140208","End":12800,"OriginalEnd":"140417","Description":"LoadAndDelete(key_0) -\u003e 1400135","Metadata":""},{"ClientId":11,"Start":14100,"OriginalStart":"145500","End":14200,"OriginalEnd":"145583","Description":"LoadOrStore(key_0, 1100082) -\u003e loaded 1400156","Metadata":""},{"ClientId":11,"Start":14300,"OriginalStart":"146792","End":14400,"OriginalEnd":"146958","Description":"Store(key_0, 1100087)","Metadata":""},{"ClientId":11,"Start":15400,"OriginalStart":"154375","End":28200,"OriginalEnd":"290500","Description":"LoadOrStore(key_0, 1100111) -\u003e loaded 1200149","Metadata":""},{"ClientId":11,"Start":30300,"OriginalStart":"524417","End":30400,"OriginalEnd":"524583","Description":"LoadAndDelete(key_0) -\u003e 1200195","Metadata":""},{"ClientId":11,"Start":30700,"OriginalStart":"525958","End":30800,"OriginalEnd":"526125","Description":"LoadOrStore(key_0, 1100139) -\u003e loaded 1300080","Metadata":""},{"ClientId":11,"Start":31100,"OriginalStart":"531625","End":31300,"OriginalEnd":"531875","Description":"LoadOrStore(key_0, 1100155) -\u003e stored","Metadata":""},{"ClientId":11,"Start":32800,"OriginalStart":"535500","End":32900,"OriginalEnd":"535958","Description":"LoadAndDelete(key_0) -\u003e 700091","Metadata":""},{"ClientId":11,"Start":33400,"OriginalStart":"537583","End":34200,"OriginalEnd":"543625","Description":"LoadOrStore(key_0, 1100173) -\u003e loaded 400128","Metadata":""},{"ClientId":11,"Start":37700,"OriginalStart":"893458","End":37800,"OriginalEnd":"893542","Description":"Load(key_0) -\u003e nil","Metadata":""},{"ClientId":11,"Start":37900,"OriginalStart":"893667","End":38000,"OriginalEnd":"893792","Description":"LoadAndDelete(key_0) -\u003e nil","Metadata":""},{"ClientId":11,"Start":38100,"OriginalStart":"894250","End":38200,"OriginalEnd":"894708","Description":"Store(key_0, 1100193)","Metadata":""},{"ClientId":12,"Start":6000,"OriginalStart":"108083","End":6100,"OriginalEnd":"108417","Description":"LoadOrStore(key_0, 1200064) -\u003e stored","Metadata":""},{"ClientId":12,"Start":6200,"OriginalStart":"108542","End":6300,"OriginalEnd":"108667","Description":"Store(key_0, 1200065)","Metadata":""},{"ClientId":12,"Start":6800,"OriginalStart":"112208","End":6900,"OriginalEnd":"112417","Description":"LoadAndDelete(key_0) -\u003e 1400058","Metadata":""},{"ClientId":12,"Start":17500,"OriginalStart":"166292","End":17600,"OriginalEnd":"166542","Description":"Store(key_0, 1200106)","Metadata":""},{"ClientId":12,"Start":23700,"OriginalStart":"202625","End":24000,"OriginalEnd":"202917","Description":"LoadAndDelete(key_0) -\u003e 700043","Metadata":""},{"ClientId":12,"Start":24100,"OriginalStart":"203708","End":24200,"OriginalEnd":"203958","Description":"LoadOrStore(key_0, 1200119) -\u003e stored","Metadata":""},{"ClientId":12,"Start":24300,"OriginalStart":"204542","End":24400,"OriginalEnd":"204792","Description":"LoadAndDelete(key_0) -\u003e 1200119","Metadata":""},{"ClientId":12,"Start":24900,"OriginalStart":"208083","End":25000,"OriginalEnd":"208208","Description":"Load(key_0) -\u003e 700063","Metadata":""},{"ClientId":12,"Start":28000,"OriginalStart":"216250","End":28100,"OriginalEnd":"216500","Description":"Store(key_0, 1200149)","Metadata":""},{"ClientId":12,"Start":28500,"OriginalStart":"508625","End":28600,"OriginalEnd":"508833","Description":"Store(key_0, 1200163)","Metadata":""},{"ClientId":12,"Start":28900,"OriginalStart":"510625","End":29000,"OriginalEnd":"510792","Description":"LoadOrStore(key_0, 1200169) -\u003e loaded 800104","Metadata":""},{"ClientId":12,"Start":29100,"OriginalStart":"512167","End":29200,"OriginalEnd":"512375","Description":"Store(key_0, 1200174)","Metadata":""},{"ClientId":12,"Start":29300,"OriginalStart":"513000","End":29400,"OriginalEnd":"513042","Description":"Load(key_0) -\u003e 1200174","Metadata":""},{"ClientId":12,"Start":29700,"OriginalStart":"517292","End":29800,"OriginalEnd":"517375","Description":"Load(key_0) -\u003e 800118","Metadata":""},{"ClientId":12,"Start":30100,"OriginalStart":"518583","End":30200,"OriginalEnd":"518833","Description":"LoadOrStore(key_0, 1200195) -\u003e stored","Metadata":""},{"ClientId":13,"Start":800,"OriginalStart":"76375","End":900,"OriginalEnd":"76708","Description":"LoadAndDelete(key_0) -\u003e 300003","Metadata":""},{"ClientId":13,"Start":1000,"OriginalStart":"77125","End":1100,"OriginalEnd":"77208","Description":"Load(key_0) -\u003e nil","Metadata":""},{"ClientId":13,"Start":1400,"OriginalStart":"78458","End":1500,"OriginalEnd":"78542","Description":"LoadAndDelete(key_0) -\u003e nil","Metadata":""},{"ClientId":13,"Start":2000,"OriginalStart":"83333","End":2100,"OriginalEnd":"83667","Description":"Store(key_0, 1300023)","Metadata":""},{"ClientId":13,"Start":2200,"OriginalStart":"84042","End":2300,"OriginalEnd":"84167","Description":"Store(key_0, 1300025)","Metadata":""},{"ClientId":13,"Start":2400,"OriginalStart":"84750","End":2500,"OriginalEnd":"84917","Description":"LoadOrStore(key_0, 1300028) -\u003e loaded 1300025","Metadata":""},{"ClientId":13,"Start":18900,"OriginalStart":"173625","End":19000,"OriginalEnd":"173708","Description":"LoadAndDelete(key_0) -\u003e nil","Metadata":""},{"ClientId":13,"Start":20900,"OriginalStart":"180917","End":21000,"OriginalEnd":"181333","Description":"Store(key_0, 1300055)","Metadata":""},{"ClientId":13,"Start":30500,"OriginalStart":"525042","End":30600,"OriginalEnd":"525333","Description":"LoadOrStore(key_0, 1300080) -\u003e stored","Metadata":""},{"ClientId":13,"Start":33500,"OriginalStart":"538875","End":33600,"OriginalEnd":"539125","Description":"LoadOrStore(key_0, 1300084) -\u003e loaded 200020","Metadata":""},{"ClientId":13,"Start":34900,"OriginalStart":"795375","End":35000,"OriginalEnd":"795500","Description":"LoadOrStore(key_0, 1300096) -\u003e loaded 100026","Metadata":""},{"ClientId":13,"Start":35300,"OriginalStart":"797792","End":35400,"OriginalEnd":"797875","Description":"Load(key_0) -\u003e 100026","Metadata":""},{"ClientId":13,"Start":35500,"OriginalStart":"798000","End":35600,"OriginalEnd":"798083","Description":"Load(key_0) -\u003e 100026","Metadata":""},{"ClientId":13,"Start":37000,"OriginalStart":"810667","End":37100,"OriginalEnd":"810750","Description":"Load(key_0) -\u003e 500054","Metadata":""},{"ClientId":13,"Start":37300,"OriginalStart":"812250","End":37400,"OriginalEnd":"812417","Description":"Load(key_0) -\u003e nil","Metadata":""},{"ClientId":13,"Start":51400,"OriginalStart":"1327542","End":51500,"OriginalEnd":"1327750","Description":"LoadAndDelete(key_0) -\u003e 900183","Metadata":""},{"ClientId":13,"Start":51700,"OriginalStart":"1328417","End":51900,"OriginalEnd":"1328625","Description":"Load(key_0) -\u003e 900186","Metadata":""},{"ClientId":13,"Start":53100,"OriginalStart":"1332458","End":53200,"OriginalEnd":"1332583","Description":"Load(key_0) -\u003e nil","Metadata":""},{"ClientId":13,"Start":53700,"OriginalStart":"1334042","End":53800,"OriginalEnd":"1334125","Description":"Load(key_0) -\u003e nil","Metadata":""},{"ClientId":13,"Start":57700,"OriginalStart":"1347667","End":57900,"OriginalEnd":"1347792","Description":"LoadAndDelete(key_0) -\u003e nil","Metadata":""},{"ClientId":13,"Start":58200,"OriginalStart":"1349042","End":58300,"OriginalEnd":"1349167","Description":"Load(key_0) -\u003e 200126","Metadata":""},{"ClientId":14,"Start":2900,"OriginalStart":"93750","End":3100,"OriginalEnd":"93917","Description":"LoadOrStore(key_0, 1400005) -\u003e loaded 300060","Metadata":""},{"ClientId":14,"Start":3200,"OriginalStart":"96500","End":3300,"OriginalEnd":"96542","Description":"Load(key_0) -\u003e 300060","Metadata":""},{"ClientId":14,"Start":3400,"OriginalStart":"96708","End":3500,"OriginalEnd":"96792","Description":"LoadOrStore(key_0, 1400015) -\u003e loaded 300060","Metadata":""},{"ClientId":14,"Start":4200,"OriginalStart":"100792","End":4300,"OriginalEnd":"100917","Description":"LoadOrStore(key_0, 1400030) -\u003e loaded 300060","Metadata":""},{"ClientId":14,"Start":5400,"OriginalStart":"105000","End":5500,"OriginalEnd":"105125","Description":"Load(key_0) -\u003e 300094","Metadata":""},{"ClientId":14,"Start":5600,"OriginalStart":"105250","End":5700,"OriginalEnd":"105625","Description":"LoadAndDelete(key_0) -\u003e 300094","Metadata":""},{"ClientId":14,"Start":6400,"OriginalStart":"109875","End":6500,"OriginalEnd":"110083","Description":"Store(key_0, 1400058)","Metadata":""},{"ClientId":14,"Start":7400,"OriginalStart":"113625","End":7600,"OriginalEnd":"114583","Description":"LoadAndDelete(key_0) -\u003e 900080","Metadata":""},{"ClientId":14,"Start":7700,"OriginalStart":"115458","End":7800,"OriginalEnd":"115792","Description":"Store(key_0, 1400071)","Metadata":""},{"ClientId":14,"Start":7900,"OriginalStart":"118167","End":8000,"OriginalEnd":"118333","Description":"Store(key_0, 1400079)","Metadata":""},{"ClientId":14,"Start":8300,"OriginalStart":"118750","End":8400,"OriginalEnd":"118917","Description":"Store(key_0, 1400081)","Metadata":""},{"ClientId":14,"Start":10400,"OriginalStart":"130292","End":10500,"OriginalEnd":"130667","Description":"Store(key_0, 1400112)","Metadata":""},{"ClientId":14,"Start":10600,"OriginalStart":"131167","End":10700,"OriginalEnd":"131417","Description":"Store(key_0, 1400114)","Metadata":""},{"ClientId":14,"Start":11200,"OriginalStart":"132833","End":11300,"OriginalEnd":"133208","Description":"LoadAndDelete(key_0) -\u003e 25","Metadata":""},{"ClientId":14,"Start":11500,"OriginalStart":"133792","End":11600,"OriginalEnd":"133958","Description":"Load(key_0) -\u003e 1100043","Metadata":""},{"ClientId":14,"Start":11700,"OriginalStart":"135083","End":11800,"OriginalEnd":"135250","Description":"Store(key_0, 1400128)","Metadata":""},{"ClientId":14,"Start":12100,"OriginalStart":"136458","End":12200,"OriginalEnd":"136750","Description":"Store(key_0, 1400132)","Metadata":""},{"ClientId":14,"Start":12300,"OriginalStart":"137625","End":12400,"OriginalEnd":"137792","Description":"Store(key_0, 1400135)","Metadata":""},{"ClientId":14,"Start":13500,"OriginalStart":"144167","End":13600,"OriginalEnd":"144375","Description":"LoadAndDelete(key_0) -\u003e 60","Metadata":""},{"ClientId":14,"Start":13700,"OriginalStart":"144875","End":14000,"OriginalEnd":"145167","Description":"Store(key_0, 1400156)","Metadata":""},{"ClientId":14,"Start":14900,"OriginalStart":"149167","End":15000,"OriginalEnd":"149292","Description":"LoadOrStore(key_0, 1400169) -\u003e loaded 1100087","Metadata":""},{"ClientId":14,"Start":15300,"OriginalStart":"154042","End":18600,"OriginalEnd":"172292","Description":"Store(key_0, 1400171)","Metadata":""},{"ClientId":14,"Start":18700,"OriginalStart":"172833","End":18800,"OriginalEnd":"173042","Description":"LoadAndDelete(key_0) -\u003e 1400171","Metadata":""},{"ClientId":14,"Start":20500,"OriginalStart":"178917","End":20600,"OriginalEnd":"179250","Description":"LoadAndDelete(key_0) -\u003e 300111","Metadata":""},{"ClientId":14,"Start":21100,"OriginalStart":"182292","End":21200,"OriginalEnd":"182625","Description":"LoadAndDelete(key_0) -\u003e 1300055","Metadata":""},{"ClientId":15,"Start":0,"OriginalStart":"63333","End":100,"OriginalEnd":"63458","Description":"Load(key_0) -\u003e nil","Metadata":""},{"ClientId":15,"Start":200,"OriginalStart":"65875","End":300,"OriginalEnd":"65958","Description":"LoadAndDelete(key_0) -\u003e nil","Metadata":""},{"ClientId":15,"Start":400,"OriginalStart":"68750","End":500,"OriginalEnd":"68917","Description":"LoadAndDelete(key_0) -\u003e nil","Metadata":""},{"ClientId":15,"Start":5800,"OriginalStart":"106958","End":5900,"OriginalEnd":"107042","Description":"Load(key_0) -\u003e nil","Metadata":""},{"ClientId":15,"Start":7100,"OriginalStart":"112708","End":7200,"OriginalEnd":"112792","Description":"Load(key_0) -\u003e nil","Metadata":""},{"ClientId":15,"Start":7500,"OriginalStart":"114250","End":10100,"OriginalEnd":"127000","Description":"LoadOrStore(key_0, 1500053) -\u003e loaded 1100024","Metadata":""},{"ClientId":15,"Start":35100,"OriginalStart":"796625","End":35200,"OriginalEnd":"796750","Description":"Load(key_0) -\u003e 100026","Metadata":""},{"ClientId":15,"Start":35700,"OriginalStart":"798458","End":35800,"OriginalEnd":"798917","Description":"LoadAndDelete(key_0) -\u003e 100026","Metadata":""},{"ClientId":15,"Start":36100,"OriginalStart":"802792","End":36200,"OriginalEnd":"803500","Description":"LoadOrStore(key_0, 1500071) -\u003e stored","Metadata":""},{"ClientId":15,"Start":55300,"OriginalStart":"1339458","End":55400,"OriginalEnd":"1339500","Description":"Load(key_0) -\u003e 100121","Metadata":""},{"ClientId":15,"Start":56300,"OriginalStart":"1342208","End":56400,"OriginalEnd":"1342333","Description":"LoadAndDelete(key_0) -\u003e nil","Metadata":""},{"ClientId":15,"Start":56700,"OriginalStart":"1345750","End":56800,"OriginalEnd":"1345958","Description":"Store(key_0, 1500121)","Metadata":""},{"ClientId":15,"Start":58000,"OriginalStart":"1348500","End":58100,"OriginalEnd":"1348625","Description":"LoadAndDelete(key_0) -\u003e nil","Metadata":""},{"ClientId":15,"Start":62400,"OriginalStart":"1368333","End":62500,"OriginalEnd":"1368667","Description":"Store(key_0, 1500152)","Metadata":""},{"ClientId":15,"Start":63000,"OriginalStart":"1370000","End":63100,"OriginalEnd":"1370167","Description":"Store(key_0, 1500158)","Metadata":""},{"ClientId":15,"Start":63900,"OriginalStart":"1374042","End":64000,"OriginalEnd":"1374125","Description":"LoadAndDelete(key_0) -\u003e nil","Metadata":""},{"ClientId":15,"Start":64100,"OriginalStart":"1376833","End":64200,"OriginalEnd":"1377042","Description":"Store(key_0, 1500183)","Metadata":""},{"ClientId":15,"Start":64300,"OriginalStart":"1379000","End":64400,"OriginalEnd":"1379083","Description":"LoadOrStore(key_0, 1500192) -\u003e loaded 1500183","Metadata":""}],"PartialLinearizations":[[{"Index":314,"StateDescription":"absent"},{"Index":315,"StateDescription":"absent"},{"Index":316,"StateDescription":"absent"},{"Index":81,"StateDescription":"value=300003"},{"Index":268,"StateDescription":"absent"},{"Index":269,"StateDescription":"absent"},{"Index":82,"StateDescription":"absent"},{"Index":270,"StateDescription":"absent"},{"Index":198,"StateDescription":"absent"},{"Index":83,"StateDescription":"absent"},{"Index":271,"StateDescription":"value=1300023"},{"Index":272,"StateDescription":"value=1300025"},{"Index":273,"StateDescription":"value=1300025"},{"Index":84,"StateDescription":"value=300060"},{"Index":85,"StateDescription":"value=300060"},{"Index":289,"StateDescription":"value=300060"},{"Index":290,"StateDescription":"value=300060"},{"Index":291,"StateDescription":"value=300060"},{"Index":199,"StateDescription":"value=300060"},{"Index":200,"StateDescription":"value=300060"},{"Index":201,"StateDescription":"value=300060"},{"Index":292,"StateDescription":"value=300060"},{"Index":86,"StateDescription":"value=300060"},{"Index":202,"StateDescription":"value=300060"},{"Index":87,"StateDescription":"value=300086"},{"Index":203,"StateDescription":"absent"},{"Index":88,"StateDescription":"value=300094"},{"Index":293,"StateDescription":"value=300094"},{"Index":294,"StateDescription":"absent"},{"Index":317,"StateDescription":"absent"},{"Index":253,"StateDescription":"value=1200064"},{"Index":254,"StateDescription":"value=1200065"},{"Index":295,"StateDescription":"value=1400058"},{"Index":204,"StateDescription":"value=1400058"},{"Index":255,"StateDescription":"absent"},{"Index":318,"StateDescription":"absent"},{"Index":205,"StateDescription":"value=900080"},{"Index":296,"StateDescription":"absent"},{"Index":297,"StateDescription":"value=1400071"},{"Index":298,"StateDescription":"value=1400079"},{"Index":206,"StateDescription":"value=1400079"},{"Index":299,"StateDescription":"value=1400081"},{"Index":207,"StateDescription":"absent"},{"Index":208,"StateDescription":"value=900103"},{"Index":209,"StateDescription":"value=900103"},{"Index":0,"StateDescription":"absent"},{"Index":1,"StateDescription":"value=5"},{"Index":2,"StateDescription":"value=5"},{"Index":238,"StateDescription":"absent"},{"Index":239,"StateDescription":"value=1100024"},{"Index":319,"StateDescription":"value=1100024"},{"Index":3,"StateDescription":"absent"},{"Index":300,"StateDescription":"value=1400112"},{"Index":301,"StateDescription":"value=1400114"},{"Index":4,"StateDescription":"value=25"},{"Index":5,"StateDescription":"value=25"},{"Index":302,"StateDescription":"absent"},{"Index":240,"StateDescription":"value=1100043"},{"Index":303,"StateDescription":"value=1100043"},{"Index":304,"StateDescription":"value=1400128"},{"Index":6,"StateDescription":"absent"},{"Index":305,"StateDescription":"value=1400132"},{"Index":306,"StateDescription":"value=1400135"},{"Index":7,"StateDescription":"value=1400135"},{"Index":241,"StateDescription":"absent"},{"Index":95,"StateDescription":"absent"},{"Index":8,"StateDescription":"absent"},{"Index":9,"StateDescription":"value=60"},{"Index":307,"StateDescription":"absent"},{"Index":96,"StateDescription":"absent"},{"Index":308,"StateDescription":"value=1400156"},{"Index":242,"StateDescription":"value=1400156"},{"Index":243,"StateDescription":"value=1100087"},{"Index":10,"StateDescription":"value=1100087"},{"Index":11,"StateDescription":"value=1100087"},{"Index":309,"StateDescription":"value=1100087"},{"Index":12,"StateDescription":"absent"},{"Index":111,"StateDescription":"absent"},{"Index":112,"StateDescription":"value=500007"},{"Index":13,"StateDescription":"value=96"},{"Index":14,"StateDescription":"value=102"},{"Index":28,"StateDescription":"value=100014"},{"Index":15,"StateDescription":"absent"},{"Index":16,"StateDescription":"absent"},{"Index":17,"StateDescription":"value=112"},{"Index":113,"StateDescription":"value=500031"},{"Index":114,"StateDescription":"value=500036"},{"Index":256,"StateDescription":"value=1200106"},{"Index":50,"StateDescription":"value=1200106"},{"Index":115,"StateDescription":"value=1200106"},{"Index":116,"StateDescription":"value=1200106"},{"Index":29,"StateDescription":"value=1200106"},{"Index":30,"StateDescription":"value=1200106"},{"Index":310,"StateDescription":"value=1400171"},{"Index":311,"StateDescription":"absent"},{"Index":274,"StateDescription":"absent"},{"Index":219,"StateDescription":"absent"},{"Index":89,"StateDescription":"value=300102"},{"Index":90,"StateDescription":"value=300102"},{"Index":220,"StateDescription":"value=1000014"},{"Index":221,"StateDescription":"absent"},{"Index":91,"StateDescription":"value=300111"},{"Index":222,"StateDescription":"value=300111"},{"Index":312,"StateDescription":"absent"},{"Index":223,"StateDescription":"absent"},{"Index":275,"StateDescription":"value=1300055"},{"Index":313,"StateDescription":"absent"},{"Index":224,"StateDescription":"absent"},{"Index":225,"StateDescription":"absent"},{"Index":226,"StateDescription":"absent"},{"Index":97,"StateDescription":"value=400055"},{"Index":227,"StateDescription":"value=400055"},{"Index":188,"StateDescription":"value=800010"},{"Index":189,"StateDescription":"value=800010"},{"Index":92,"StateDescription":"value=300154"},{"Index":93,"StateDescription":"value=300158"},{"Index":165,"StateDescription":"value=300158"},{"Index":98,"StateDescription":"value=400074"},{"Index":166,"StateDescription":"value=700043"},{"Index":167,"StateDescription":"value=700043"},{"Index":257,"StateDescription":"absent"},{"Index":258,"StateDescription":"value=1200119"},{"Index":259,"StateDescription":"absent"},{"Index":168,"StateDescription":"absent"},{"Index":169,"StateDescription":"value=700063"},{"Index":260,"StateDescription":"value=700063"},{"Index":170,"StateDescription":"value=700063"},{"Index":138,"StateDescription":"value=700063"},{"Index":190,"StateDescription":"absent"},{"Index":228,"StateDescription":"absent"},{"Index":139,"StateDescription":"absent"},{"Index":99,"StateDescription":"value=400110"},{"Index":191,"StateDescription":"value=400110"},{"Index":100,"StateDescription":"value=400111"},{"Index":140,"StateDescription":"absent"},{"Index":192,"StateDescription":"value=800079"},{"Index":141,"StateDescription":"value=800079"},{"Index":101,"StateDescription":"value=800079"},{"Index":142,"StateDescription":"absent"},{"Index":229,"StateDescription":"value=1000092"},{"Index":143,"StateDescription":"value=1000092"},{"Index":261,"StateDescription":"value=1200149"},{"Index":244,"StateDescription":"value=1200149"},{"Index":193,"StateDescription":"value=800092"},{"Index":262,"StateDescription":"value=1200163"},{"Index":194,"StateDescription":"value=800104"},{"Index":263,"StateDescription":"value=800104"},{"Index":264,"StateDescription":"value=1200174"},{"Index":265,"StateDescription":"value=1200174"},{"Index":195,"StateDescription":"value=800118"},{"Index":266,"StateDescription":"value=800118"},{"Index":196,"StateDescription":"absent"},{"Index":267,"StateDescription":"value=1200195"},{"Index":245,"StateDescription":"absent"},{"Index":276,"StateDescription":"value=1300080"},{"Index":246,"StateDescription":"value=1300080"},{"Index":171,"StateDescription":"absent"},{"Index":247,"StateDescription":"value=1100155"},{"Index":172,"StateDescription":"absent"},{"Index":173,"StateDescription":"value=700086"},{"Index":174,"StateDescription":"value=700086"},{"Index":197,"StateDescription":"value=800185"},{"Index":175,"StateDescription":"value=700091"},{"Index":51,"StateDescription":"value=700091"},{"Index":176,"StateDescription":"value=700091"},{"Index":248,"StateDescription":"absent"},{"Index":52,"StateDescription":"value=200019"},{"Index":53,"StateDescription":"value=200020"}]],"Largest":{"0":0,"1":0,"10":0,"100":0,"101":0,"11":0,"111":0,"112":0,"113":0,"114":0,"115":0,"116":0,"12":0,"13":0,"138":0,"139":0,"14":0,"140":0,"141":0,"142":0,"143":0,"15":0,"16":0,"165":0,"166":0,"167":0,"168":0,"169":0,"17":0,"170":0,"171":0,"172":0,"173":0,"174":0,"175":0,"176":0,"188":0,"189":0,"190":0,"191":0,"192":0,"193":0,"194":0,"195":0,"196":0,"197":0,"198":0,"199":0,"2":0,"200":0,"201":0,"202":0,"203":0,"204":0,"205":0,"206":0,"207":0,"208":0,"209":0,"219":0,"220":0,"221":0,"222":0,"223":0,"224":0,"225":0,"226":0,"227":0,"228":0,"229":0,"238":0,"239":0,"240":0,"241":0,"242":0,"243":0,"244":0,"245":0,"246":0,"247":0,"248":0,"253":0,"254":0,"255":0,"256":0,"257":0,"258":0,"259":0,"260":0,"261":0,"262":0,"263":0,"264":0,"265":0,"266":0,"267":0,"268":0,"269":0,"270":0,"271":0,"272":0,"273":0,"274":0,"275":0,"276":0,"28":0,"289":0,"29":0,"290":0,"291":0,"292":0,"293":0,"294":0,"295":0,"296":0,"297":0,"298":0,"299":0,"3":0,"30":0,"300":0,"301":0,"302":0,"303":0,"304":0,"305":0,"306":0,"307":0,"308":0,"309":0,"310":0,"311":0,"312":0,"313":0,"314":0,"315":0,"316":0,"317":0,"318":0,"319":0,"4":0,"5":0,"50":0,"51":0,"52":0,"53":0,"6":0,"7":0,"8":0,"81":0,"82":0,"83":0,"84":0,"85":0,"86":0,"87":0,"88":0,"89":0,"9":0,"90":0,"91":0,"92":0,"93":0,"95":0,"96":0,"97":0,"98":0,"99":0}}],"Annotations":[]}
+
+      render(data)
+    </script>
+  </body>
+</html>

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/bytedance/gopkg
 go 1.18
 
 require (
+	github.com/anishathalye/porcupine v1.1.0
 	golang.org/x/sync v0.11.0
 	golang.org/x/sys v0.30.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/anishathalye/porcupine v1.1.0 h1:jkMLqDejaWqvhvjxYKyqwQO3d1Jw+/08wHiIw0O4wcU=
+github.com/anishathalye/porcupine v1.1.0/go.mod h1:WM0SsFjWNl2Y4BqHr/E/ll2yY1GY1jqn+W7Z/84Zoog=
 golang.org/x/sync v0.11.0 h1:GGz8+XQP4FvTTrjZPzNKTMFtSXH80RAzG+5ghFPgK9w=
 golang.org/x/sync v0.11.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
 golang.org/x/sys v0.30.0 h1:QjkSwP/36a20jFYWkSue1YwXzLmsV5Gfq7Eiy72C1uc=


### PR DESCRIPTION
This Pull Request is for demonstrating a skipmap linearizability failure. See reported issue.

<img width="1731" height="469" alt="Screenshot 2026-03-18 at 5 22 37 pm" src="https://github.com/user-attachments/assets/554b7ac4-eaf2-408f-b34d-b6a6ba7250c4" />

\
**Observed timeline**

```
LoadAndDelete(key_0) -> 700091   [deletes the old value]
Store(key_0, 200019)             [concurrent, should install new value]
LoadAndDelete(key_0) -> nil      [value from Store is gone]
```

There is no valid linearization of these operations: if `Store(key_0, 200019)` linearizes after the first LoadAndDelete, the key should hold 200019. The second LoadAndDelete returning nil means the Store's effect was lost without any corresponding delete.