### PR TITLE
 fix(xxh3): remove duplicated keyed assignments in xxh3Len0To16_128b

### DIFF
--- a/cloud/circuitbreaker/panel.go
+++ b/cloud/circuitbreaker/panel.go
@@ -93,7 +93,7 @@ func (p *panel) getBreaker(key string) *breaker {
 		}
 	}
 	ncb, _ := newBreaker(op)
-	cb, ok = p.breakers.LoadOrStore(key, ncb)
+	cb, _ = p.breakers.LoadOrStore(key, ncb)
 	return cb.(*breaker)
 }
 

--- a/util/gctuner/tuner.go
+++ b/util/gctuner/tuner.go
@@ -117,7 +117,6 @@ func (t *tuner) tuning() {
 		return
 	}
 	t.setGCPercent(calcGCPercent(inuse, threshold))
-	return
 }
 
 // threshold = inuse + inuse * (gcPercent / 100)

--- a/util/xxhash3/internal/xxh3_raw/xxh3_raw.go
+++ b/util/xxhash3/internal/xxh3_raw/xxh3_raw.go
@@ -235,9 +235,6 @@ func xxh3Len0To16_128b(xinput unsafe.Pointer, len uint64) [2]uint64 {
 		keyedLow := combinedl ^ bitflipl
 		keyedHigh := combinedh ^ bitfliph
 
-		keyedLow = combinedl ^ bitflipl
-		keyedHigh = combinedh ^ bitfliph
-
 		h128Low64 := xxh64Avalanche(keyedLow)
 		h128High64 := xxh64Avalanche(keyedHigh)
 		return [2]uint64{h128High64, h128Low64}


### PR DESCRIPTION

#### What type of PR is this?
fix

#### Translate the PR title into Chinese.
`fix(xxh3): 移除 xxh3Len0To16_128b 中重复的 keyedLow/keyedHigh 赋值`

#### More detailed description for this PR

##### en
In `xxh3Len0To16_128b`, the `keyedLow`/`keyedHigh` variables were assigned twice with identical expressions:

```go
keyedLow := combinedl ^ bitflipl
keyedHigh := combinedh ^ bitfliph
keyedLow = combinedl ^ bitflipl   // duplicated, first pair never used
keyedHigh = combinedh ^ bitfliph  // duplicated
```

The first pair of assignments is never used (immediately overwritten), flagged by staticcheck as SA4006. This looks like a leftover from an edit/merge. Removing the duplicated lines does not change the hash output (identical expressions), and all xxhash3 tests pass.

Also cleaned up two minor staticcheck warnings in the same repo:
- cloud/circuitbreaker/panel.go: unused ok return value (SA4006)
- util/gctuner/tuner.go: redundant return statement (S1023)

##### zh
在 xxh3Len0To16_128b 中，keyedLow/keyedHigh 被用完全相同的表达式赋值了两次，第一对赋值从未被使用（随即被覆盖），staticcheck 检出 SA4006 告警，该冗余代码疑似代码编辑、分支合并后遗留内容。删除重复代码行不会改变哈希计算结果（两次赋值运算逻辑一致），xxhash3 全量测试用例执行通过。

本次同步清理仓库内两处轻微的 staticcheck 静态检查告警：
- cloud/circuitbreaker/panel.go：未使用的 ok 返回值 (SA4006)
- util/gctuner/tuner.go：冗余 return 返回语句 (S1023)